### PR TITLE
Replace photo-add button text with icon

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil } from "lucide-react";
+import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil, Plus } from "lucide-react";
 import { seedStations } from "./seed_stations";
 import WordArtLogo from "./components/WordArtLogo";
 import LineChips from "./components/LineChips";
@@ -416,10 +416,16 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
                         </button>
                       ))}
                       <button
-                        className="w-full h-10 md:h-12 rounded-xl border-2 border-dashed border-black flex items-center justify-center text-sm bg-white"
+                        className="w-full aspect-square rounded-xl border-2 border-dashed border-black flex items-center justify-center bg-white"
                         onClick={()=>{ setPendingPhoto({stationId:st.id, index:idx}); fileRef.current?.click(); }}
                       >
-                        {(v.photos && v.photos.length) ? 'Weitere Fotos hinzufügen' : 'Kein Foto – Foto hinzufügen'}
+                        <span className="relative">
+                          <Camera size={24}/>
+                          <Plus
+                            size={14}
+                            className="absolute top-0 right-0 -translate-x-1/2 translate-y-1/2 bg-white rounded-full border border-black"
+                          />
+                        </span>
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Use square button with camera-plus icon for adding photos
- Center plus overlay inside camera icon

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68992573161c832dbe09968ce3594d75