### PR TITLE
Add simple login and server storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.539.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,50 @@
+import http from 'http';
+import { parse } from 'url';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto';
+
+const DB_FILE = new URL('./db.json', import.meta.url);
+let db = { users: [], data: {}, sessions: {} };
+if (existsSync(DB_FILE)) {
+  try { db = JSON.parse(readFileSync(DB_FILE, 'utf8')); } catch { /* ignore */ }
+}
+function saveDb(){ writeFileSync(DB_FILE, JSON.stringify(db, null, 2)); }
+function hashPassword(password){ const salt=randomBytes(16).toString('hex'); const hash=scryptSync(password,salt,64).toString('hex'); return `${salt}:${hash}`; }
+function verifyPassword(password, stored){ const [salt,hash]=stored.split(':'); const hashed=scryptSync(password,salt,64); return timingSafeEqual(Buffer.from(hash,'hex'), hashed); }
+function parseBody(req){ return new Promise((resolve)=>{ let body=''; req.on('data',c=>body+=c); req.on('end',()=>{ try{ resolve(JSON.parse(body||'{}')); }catch{ resolve({}); } }); }); }
+function auth(req){ const auth=req.headers['authorization']; if(!auth) return null; const token=auth.split(' ')[1]; const uid=db.sessions[token]; return uid? {id:uid}: null; }
+
+const server = http.createServer(async (req,res)=>{
+  const { pathname } = parse(req.url, true);
+  if (req.method==='POST' && pathname==='/api/register'){
+    const {username,password} = await parseBody(req);
+    if(!username || !password){ res.writeHead(400); return res.end(JSON.stringify({error:'missing'})); }
+    if(db.users.find(u=>u.username===username)){ res.writeHead(400); return res.end(JSON.stringify({error:'exists'})); }
+    const id = db.users.length? Math.max(...db.users.map(u=>u.id))+1 : 1;
+    db.users.push({id, username, password:hashPassword(password)});
+    saveDb();
+    res.end(JSON.stringify({success:true}));
+  }
+  else if (req.method==='POST' && pathname==='/api/login'){
+    const {username,password} = await parseBody(req);
+    const user=db.users.find(u=>u.username===username);
+    if(!user || !verifyPassword(password,user.password)){ res.writeHead(401); return res.end(JSON.stringify({error:'invalid'})); }
+    const token=randomBytes(24).toString('hex'); db.sessions[token]=user.id; saveDb();
+    res.end(JSON.stringify({token}));
+  }
+  else if (req.method==='GET' && pathname==='/api/data'){
+    const user=auth(req); if(!user){ res.writeHead(401); return res.end(JSON.stringify({error:'noauth'})); }
+    res.end(JSON.stringify({data: db.data[user.id] || null}));
+  }
+  else if (req.method==='POST' && pathname==='/api/data'){
+    const user=auth(req); if(!user){ res.writeHead(401); return res.end(JSON.stringify({error:'noauth'})); }
+    const {data} = await parseBody(req); db.data[user.id]=data; saveDb();
+    res.end(JSON.stringify({success:true}));
+  }
+  else {
+    res.writeHead(404); res.end('not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => console.log('Server listening on '+PORT));

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { login, register } from './api.js';
+
+export default function Login({ onSuccess }){
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [mode, setMode] = useState('login');
+  const [error, setError] = useState('');
+
+  async function submit(e){
+    e.preventDefault();
+    try {
+      if (mode === 'register') {
+        await register(username, password);
+      }
+      const token = await login(username, password);
+      onSuccess(token, username);
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-2 p-4 border-4 border-black bg-white rounded-xl w-80">
+      <div><input value={username} onChange={e=>setUsername(e.target.value)} placeholder="Username" className="w-full border p-2"/></div>
+      <div><input type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="Password" className="w-full border p-2"/></div>
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+      <button type="submit" className="w-full bg-black text-white p-2 rounded">{mode==='login'? 'Login' : 'Registrieren'}</button>
+      <button type="button" className="text-sm underline" onClick={()=>setMode(mode==='login'?'register':'login')}>
+        {mode==='login' ? 'Neu hier? Registrieren' : 'Schon registriert? Login'}
+      </button>
+    </form>
+  );
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,21 @@
+export async function register(username, password){
+  const res = await fetch('/api/register', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username, password})});
+  if(!res.ok) throw new Error('Register failed');
+}
+export async function login(username, password){
+  const res = await fetch('/api/login', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username, password})});
+  if(!res.ok) throw new Error('Login failed');
+  const data = await res.json();
+  localStorage.setItem('authToken', data.token);
+  return data.token;
+}
+export function logout(){ localStorage.removeItem('authToken'); }
+export async function fetchData(token){
+  const res = await fetch('/api/data', {headers:{'Authorization':`Bearer ${token}`}});
+  if(!res.ok) return null;
+  const {data} = await res.json();
+  return data;
+}
+export async function saveData(token, data){
+  await fetch('/api/data', {method:'POST', headers:{'Content-Type':'application/json','Authorization':`Bearer ${token}`}, body: JSON.stringify({data})});
+}


### PR DESCRIPTION
## Summary
- add minimal http server with registration, login and user data storage
- implement client login form and API helpers
- sync station data with server and expose logout option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68992a2bb770832d8d71228dd7c69c67