### PR TITLE
Handle localStorage quota exceeded during login

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -87,10 +87,23 @@ export default function App(){
   const [cooldownEnabled, setCooldownEnabled] = useState(()=>{ try{ return JSON.parse(localStorage.getItem(COOLDOWN_KEY) ?? "true"); }catch{ return true; }});
 
   useEffect(()=>{
-    if(token){ saveData(token, stations).catch(()=>{}); }
-    else { localStorage.setItem(STORAGE_KEY, JSON.stringify(stations)); }
+    if(token){
+      saveData(token, stations).catch(()=>{});
+    } else {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(stations));
+      } catch (e) {
+        console.warn('Failed to persist stations to localStorage', e);
+      }
+    }
   }, [stations, token]);
-  useEffect(()=>{ localStorage.setItem(COOLDOWN_KEY, JSON.stringify(cooldownEnabled)); }, [cooldownEnabled]);
+  useEffect(()=>{
+    try {
+      localStorage.setItem(COOLDOWN_KEY, JSON.stringify(cooldownEnabled));
+    } catch (e) {
+      console.warn('Failed to persist cooldown flag', e);
+    }
+  }, [cooldownEnabled]);
   useEffect(()=>{
     if(token){
       fetchData(token).then(data=>{ if(data) setStations(normalizeStations(data)); }).catch(()=>setToken(null));

--- a/src/api.js
+++ b/src/api.js
@@ -6,7 +6,19 @@ export async function login(username, password){
   const res = await fetch('/api/login', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username, password})});
   if(!res.ok) throw new Error('Login failed');
   const data = await res.json();
-  localStorage.setItem('authToken', data.token);
+  try {
+    localStorage.setItem('authToken', data.token);
+  } catch (e) {
+    // Speicher voll? alte lokale Daten entfernen und erneut versuchen
+    console.warn('Auth token could not be stored, trying to free space', e);
+    try {
+      localStorage.removeItem('zufallstour3000.v4');
+      localStorage.setItem('authToken', data.token);
+    } catch (e2) {
+      console.error('Failed to store auth token', e2);
+      throw e2;
+    }
+  }
   return data.token;
 }
 export function logout(){ localStorage.removeItem('authToken'); }


### PR DESCRIPTION
## Summary
- Guard localStorage writes for stations and cooldown to avoid quota errors
- Clear large offline data and retry when storing auth token fails

## Testing
- `npm test`
- `npm run lint` *(fails: Buffer is not defined, process is not defined, multiple react-refresh/only-export-components and react-hooks rules-of-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_689931beb1ac832d9943dba897028ed8