### PR TITLE
Add all stations page with smart filters

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global Buffer, process */
 import http from 'http';
 import { parse } from 'url';
 import { existsSync, readFileSync, writeFileSync } from 'fs';


### PR DESCRIPTION
## Summary
- add all stations view with line, unvisited and longest-since filters
- expose navigation link to all stations list
- fix server lint errors by marking node globals

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68993457646c832da49bccb6d52b2a49