### PR TITLE
Add station type prefixes to names and travel links

### DIFF
--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, googleMapsUrl, pickThreeUnvisited, rollAllowed, makeDataUrl } from '../src/App.jsx';
+import { formatDate, googleMapsUrl, pickThreeUnvisited, rollAllowed, makeDataUrl, stationLabel } from '../src/App.jsx';
 
 describe('utility functions', () => {
   it('formats ISO dates in de-DE format', () => {
@@ -15,6 +15,11 @@ describe('utility functions', () => {
 
     const g2 = googleMapsUrl('Frankfurter Allee');
     expect(g2).toContain('Frankfurter%20Allee');
+  });
+
+  it('prefixes station names with their types', () => {
+    expect(stationLabel({ name: 'Ullsteinstraße', types: ['U'] })).toBe('U Ullsteinstraße');
+    expect(stationLabel({ name: 'Alexanderplatz', types: ['S', 'U'] })).toBe('S+U Alexanderplatz');
   });
 
   it('picks up to three unique unvisited stations', () => {


### PR DESCRIPTION
## Summary
- prefix station names with their S/U/R letters for API lookups
- show journey estimate (or `n/a`) inline after station names
- cover station prefix logic with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68994d1a59d8832dac1b1678a010da24