### PR TITLE
Add password change endpoint and UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,16 @@ const server = http.createServer(async (req,res)=>{
     const {data} = await parseBody(req); db.data[user.id]=data; saveDb();
     res.end(JSON.stringify({success:true}));
   }
+  else if (req.method==='POST' && pathname==='/api/password'){
+    const user=auth(req); if(!user){ res.writeHead(401); return res.end(JSON.stringify({error:'noauth'})); }
+    const {oldPassword, newPassword} = await parseBody(req);
+    const u = db.users.find(u=>u.id===user.id);
+    if(!u || !oldPassword || !newPassword || !verifyPassword(oldPassword, u.password)){
+      res.writeHead(400); return res.end(JSON.stringify({error:'invalid'}));
+    }
+    u.password = hashPassword(newPassword); saveDb();
+    res.end(JSON.stringify({success:true}));
+  }
   else {
     res.writeHead(404); res.end('not found');
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import ManualVisitForm from "./components/ManualVisitForm";
 import ZoomBox from "./components/ZoomBox";
 import Login from "./Login";
 import { fetchData, saveData, logout as apiLogout } from "./api.js";
+import ChangePassword from "./ChangePassword";
 
 // Helpers & Types
 const STORAGE_KEY = "zufallstour3000.v4";
@@ -376,6 +377,7 @@ export default function App(){
             </label>
             <p className="text-xs mt-1 opacity-80">Deaktivieren, um ohne „srsly?“-Hinweis schnell zu würfeln.</p>
           </div>
+          <ChangePassword />
         </Modal>
 
         <Modal open={exportDialog.open} onClose={()=>{ try{ URL.revokeObjectURL(exportDialog.href);}catch{ /* ignore */ } setExportDialog(p=>({...p, open:false})); }} title="Backup exportiert">

--- a/src/ChangePassword.jsx
+++ b/src/ChangePassword.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { changePassword } from './api.js';
+
+export default function ChangePassword(){
+  const [oldPw, setOldPw] = useState('');
+  const [newPw, setNewPw] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  async function submit(e){
+    e.preventDefault();
+    setMessage('');
+    setError('');
+    try {
+      await changePassword(oldPw, newPw);
+      setMessage('Passwort aktualisiert');
+      setOldPw('');
+      setNewPw('');
+    } catch (e) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border-4 border-black p-4 bg-white/80 mt-4">
+      <h3 className="font-extrabold text-lg mb-2">Passwort ändern</h3>
+      <form onSubmit={submit} className="space-y-2">
+        <div><input type="password" value={oldPw} onChange={e=>setOldPw(e.target.value)} placeholder="Altes Passwort" className="w-full px-3 py-2 rounded-lg border-4 border-black bg-white text-sm"/></div>
+        <div><input type="password" value={newPw} onChange={e=>setNewPw(e.target.value)} placeholder="Neues Passwort" className="w-full px-3 py-2 rounded-lg border-4 border-black bg-white text-sm"/></div>
+        {message && <div className="text-green-600 text-sm">{message}</div>}
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <button type="submit" className="px-4 py-2 rounded-full bg-black text-white font-extrabold border-4 border-black w-full">Speichern</button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/api.js
+++ b/src/api.js
@@ -31,3 +31,16 @@ export async function fetchData(token){
 export async function saveData(token, data){
   await fetch('/api/data', {method:'POST', headers:{'Content-Type':'application/json','Authorization':`Bearer ${token}`}, body: JSON.stringify({data})});
 }
+
+export async function changePassword(oldPw, newPw){
+  const token = localStorage.getItem('authToken');
+  const res = await fetch('/api/password', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json','Authorization':`Bearer ${token}`},
+    body: JSON.stringify({ oldPassword: oldPw, newPassword: newPw })
+  });
+  if(!res.ok){
+    const data = await res.json().catch(()=>({}));
+    throw new Error(data.error || 'Change password failed');
+  }
+}


### PR DESCRIPTION
## Summary
- add POST /api/password endpoint to update hashed credentials
- expose changePassword API wrapper and integrate ChangePassword form in settings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899cf8e9d1c832daf8f044b79baceae