### PR TITLE
feat: add account deletion

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,16 @@ const server = http.createServer(async (req,res)=>{
     const {data} = await parseBody(req); db.data[user.id]=data; saveDb();
     res.end(JSON.stringify({success:true}));
   }
+  else if (req.method==='DELETE' && pathname==='/api/account'){
+    const user=auth(req); if(!user){ res.writeHead(401); return res.end(JSON.stringify({error:'noauth'})); }
+    db.users = db.users.filter(u=>u.id!==user.id);
+    delete db.data[user.id];
+    for(const [t,uid] of Object.entries(db.sessions)){
+      if(uid===user.id) delete db.sessions[t];
+    }
+    saveDb();
+    res.end(JSON.stringify({success:true}));
+  }
   else {
     res.writeHead(404); res.end('not found');
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import ComboBox from "./components/ComboBox";
 import ManualVisitForm from "./components/ManualVisitForm";
 import ZoomBox from "./components/ZoomBox";
 import Login from "./Login";
-import { fetchData, saveData, logout as apiLogout } from "./api.js";
+import { fetchData, saveData, logout as apiLogout, deleteAccount } from "./api.js";
 
 // Helpers & Types
 const STORAGE_KEY = "zufallstour3000.v4";
@@ -88,6 +88,7 @@ export default function App(){
   const [showSettings, setShowSettings] = useState(false);
   const [addVisitFor, setAddVisitFor] = useState/** @type {Station|null} */(null);
   const [exportDialog, setExportDialog] = useState({open:false, href:"", filename:"", text:""});
+  const [showDeleteAccount, setShowDeleteAccount] = useState(false);
   const [denyShake, setDenyShake] = useState(false);
   const [denyMessage, setDenyMessage] = useState("");
   const lastRollRef = useRef(0);
@@ -168,6 +169,20 @@ export default function App(){
 
   function handleLogin(tok){ setToken(tok); }
   function handleLogout(){ apiLogout(); setToken(null); }
+  async function confirmDeleteAccount(){
+    if(!token) return;
+    try{
+      await deleteAccount(token);
+  }catch{
+      alert('Konto löschen fehlgeschlagen');
+      return;
+    }
+    try{ localStorage.removeItem(STORAGE_KEY); }catch{ /* ignore */ }
+    setStations(makeSeed());
+    apiLogout();
+    setShowDeleteAccount(false);
+    setToken(null);
+  }
 
   if(!token){
     return (
@@ -376,6 +391,13 @@ export default function App(){
             </label>
             <p className="text-xs mt-1 opacity-80">Deaktivieren, um ohne „srsly?“-Hinweis schnell zu würfeln.</p>
           </div>
+          <div className="mt-4 rounded-2xl border-4 border-black p-4 bg-white/80">
+            <h3 className="font-extrabold text-lg mb-2">Konto</h3>
+            <button
+              onClick={()=>setShowDeleteAccount(true)}
+              className="px-4 py-2 rounded-full bg-red-600 text-white font-extrabold border-4 border-black flex items-center gap-2"
+            ><Trash2 size={18}/> Konto löschen</button>
+          </div>
         </Modal>
 
         <Modal open={exportDialog.open} onClose={()=>{ try{ URL.revokeObjectURL(exportDialog.href);}catch{ /* ignore */ } setExportDialog(p=>({...p, open:false})); }} title="Backup exportiert">
@@ -383,6 +405,13 @@ export default function App(){
             <p className="text-sm">Falls dein Browser den automatischen Download blockiert, nutze diesen Link:</p>
             <a href={exportDialog.href} download={exportDialog.filename} className="px-4 py-2 rounded-full bg-green-500 border-4 border-black font-extrabold inline-flex items-center gap-2 cursor-pointer"><Download size={18}/> {exportDialog.filename}</a>
             <div><p className="text-sm mb-1">Oder kopiere den JSON-Inhalt:</p><textarea readOnly value={exportDialog.text} className="w-full h-40 p-2 rounded-lg border-4 border-black bg-white text-xs"></textarea></div>
+          </div>
+        </Modal>
+
+        <Modal open={showDeleteAccount} onClose={()=>setShowDeleteAccount(false)} title="Konto löschen">
+          <div className="space-y-3">
+            <p className="text-sm">Willst du dein Konto dauerhaft löschen? Alle Daten werden entfernt.</p>
+            <div className="flex gap-2 justify-end"><button onClick={()=>setShowDeleteAccount(false)} className="px-4 py-2 rounded-lg bg-white border-2 border-black">Abbrechen</button><button onClick={confirmDeleteAccount} className="px-4 py-2 rounded-lg bg-red-600 text-white border-2 border-black">Löschen</button></div>
           </div>
         </Modal>
 

--- a/src/api.js
+++ b/src/api.js
@@ -31,3 +31,7 @@ export async function fetchData(token){
 export async function saveData(token, data){
   await fetch('/api/data', {method:'POST', headers:{'Content-Type':'application/json','Authorization':`Bearer ${token}`}, body: JSON.stringify({data})});
 }
+export async function deleteAccount(token){
+  const res = await fetch('/api/account', {method:'DELETE', headers:{'Authorization':`Bearer ${token}`}});
+  if(!res.ok) throw new Error('Delete failed');
+}


### PR DESCRIPTION
## Summary
- add DELETE /api/account endpoint to remove user data and sessions
- expose deleteAccount() client helper
- provide UI to delete account with confirmation and redirect to login

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899cf909bec832dbb6e8cb99b3f4928