### PR TITLE
Reset session data on logout

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,15 @@ const server = http.createServer(async (req,res)=>{
     const token=randomBytes(24).toString('hex'); db.sessions[token]=user.id; saveDb();
     res.end(JSON.stringify({token}));
   }
+  else if (req.method==='POST' && pathname==='/api/logout'){
+    const authHeader=req.headers['authorization'];
+    if(authHeader){
+      const token=authHeader.split(' ')[1];
+      delete db.sessions[token];
+      saveDb();
+    }
+    res.end(JSON.stringify({success:true}));
+  }
   else if (req.method==='GET' && pathname==='/api/data'){
     const user=auth(req); if(!user){ res.writeHead(401); return res.end(JSON.stringify({error:'noauth'})); }
     res.end(JSON.stringify({data: db.data[user.id] || null}));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -167,19 +167,29 @@ export default function App(){
   }, [stations]);
   const photoCount = useMemo(()=> stations.reduce((acc,s)=> acc + s.visits.reduce((sum,v)=> sum + (v.photos?.length||0),0),0), [stations]);
 
-  function handleLogin(tok){ setToken(tok); }
-  function handleLogout(){ apiLogout(); setToken(null); }
+  function handleLogin(tok){
+    try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    setStations(makeSeed());
+    setToken(tok);
+  }
+  async function handleLogout(){
+    const current = token;
+    try { if (current) await apiLogout(current); } catch { /* ignore */ }
+    try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    setStations(makeSeed());
+    setToken(null);
+  }
   async function confirmDeleteAccount(){
     if(!token) return;
     try{
       await deleteAccount(token);
-  }catch{
+    }catch{
       alert('Konto löschen fehlgeschlagen');
       return;
     }
     try{ localStorage.removeItem(STORAGE_KEY); }catch{ /* ignore */ }
     setStations(makeSeed());
-    apiLogout();
+    try { await apiLogout(token); } catch { /* ignore */ }
     setShowDeleteAccount(false);
     setToken(null);
   }

--- a/src/api.js
+++ b/src/api.js
@@ -21,7 +21,10 @@ export async function login(username, password){
   }
   return data.token;
 }
-export function logout(){ localStorage.removeItem('authToken'); }
+export async function logout(token){
+  try { await fetch('/api/logout', { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } }); } catch { /* ignore */ }
+  try { localStorage.removeItem('authToken'); } catch { /* ignore */ }
+}
 export async function fetchData(token){
   const res = await fetch('/api/data', {headers:{'Authorization':`Bearer ${token}`}});
   if(!res.ok) return null;


### PR DESCRIPTION
## Summary
- ensure each login starts with fresh local data
- invalidate sessions server-side and clear local storage on logout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2dade588832d9da1d28f2923d0f1