### PR TITLE
feat: unify button styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -339,7 +339,7 @@ export default function App(){
               <div className="font-extrabold text-sm">Fortschritt</div>
               <div className="text-xs opacity-80">{visitedCount}/{total} ({percent}%)</div>
               <div className="text-xs opacity-80 flex items-center gap-1"><Camera size={12}/> {photoCount}</div>
-              <button onClick={()=>setShowMilestones(true)} className="ml-auto text-xs px-2 py-1 rounded-full border-2 border-black bg-white flex items-center gap-1"><Trophy size={14}/> Meilensteine</button>
+              <button onClick={()=>setShowMilestones(true)} className="ml-auto text-xs px-2 py-1 rounded-full bg-white flex items-center gap-1"><Trophy size={14}/> Meilensteine</button>
             </div>
             <div onClick={()=>setShowMilestones(true)} className="relative h-4 rounded-full border-4 border-black bg-white cursor-pointer">
               <div className="h-full bg-green-500" style={{width:`${Math.max(4,percent)}%`}} />
@@ -350,12 +350,12 @@ export default function App(){
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-            <button onClick={doRoll} className={`w-full justify-center px-6 py-3 rounded-full text-xl font-black bg-gradient-to-r from-fuchsia-500 via-pink-500 to-orange-400 text-white border-4 border-black shadow-[6px_6px_0_0_rgba(0,0,0,0.6)] active:translate-y-[2px] active:shadow-[4px_4px_0_0_rgba(0,0,0,0.6)] flex items-center`} style={denyShake?{animation:"shake .6s"}:{}}>
+            <button onClick={doRoll} className={`w-full justify-center px-6 py-3 rounded-full text-xl font-black bg-gradient-to-r from-fuchsia-500 via-pink-500 to-orange-400 text-white flex items-center`} style={denyShake?{animation:"shake .6s"}:{}}>
               <span className="inline-flex items-center gap-2 mx-auto"><Shuffle size={22}/> WÜRFELN</span>
             </button>
-            <button onClick={()=>setPage('visited')} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 border-4 border-black shadow hover:brightness-110 active:translate-y-[1px]">Besuchte Bahnhöfe</button>
-            <button onClick={()=>setPage('stations')} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 border-4 border-black shadow hover:brightness-110 active:translate-y-[1px]">Alle Bahnhöfe</button>
-            <button onClick={()=>setShowSettings(true)} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-black text-white flex items-center border-4 border-black shadow" aria-label="Einstellungen" title="Einstellungen"><SettingsIcon size={20}/></button>
+            <button onClick={()=>setPage('visited')} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 hover:brightness-110">Besuchte Bahnhöfe</button>
+            <button onClick={()=>setPage('stations')} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 hover:brightness-110">Alle Bahnhöfe</button>
+            <button onClick={()=>setShowSettings(true)} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-black text-white flex items-center" aria-label="Einstellungen" title="Einstellungen"><SettingsIcon size={20}/></button>
           </div>
 
           {lastVisitDate && (<div className="mt-3 text-sm opacity-80">Letzter Besuch: <b>{formatDate(lastVisitDate)}</b></div>)}
@@ -447,7 +447,7 @@ export default function App(){
         <Modal open={showDeleteAccount} onClose={()=>setShowDeleteAccount(false)} title="Konto löschen">
           <div className="space-y-3">
             <p className="text-sm">Willst du dein Konto dauerhaft löschen? Alle Daten werden entfernt.</p>
-            <div className="flex gap-2 justify-end"><button onClick={()=>setShowDeleteAccount(false)} className="px-4 py-2 rounded-lg bg-white border-2 border-black">Abbrechen</button><button onClick={confirmDeleteAccount} className="px-4 py-2 rounded-lg bg-red-600 text-white border-2 border-black">Löschen</button></div>
+            <div className="flex gap-2 justify-end"><button onClick={()=>setShowDeleteAccount(false)} className="px-4 py-2 rounded-lg bg-white">Abbrechen</button><button onClick={confirmDeleteAccount} className="px-4 py-2 rounded-lg bg-red-600 text-white">Löschen</button></div>
           </div>
         </Modal>
 
@@ -543,16 +543,16 @@ function StationsPage({ stations, onBack }){
           <button
             key={t}
             onClick={()=>toggleType(t)}
-            className={`px-3 py-1 rounded-full border-2 border-black ${typeFilter[t]?"bg-black text-white":"bg-white"}`}
+            className={`px-3 py-1 rounded-full ${typeFilter[t]?"bg-black text-white":"bg-white"}`}
           >{t}</button>
         ))}
         <button
           onClick={()=>setOnlyUnvisited(v=>!v)}
-          className={`px-3 py-1 rounded-full border-2 border-black ${onlyUnvisited?"bg-black text-white":"bg-white"}`}
+          className={`px-3 py-1 rounded-full ${onlyUnvisited?"bg-black text-white":"bg-white"}`}
         >Noch nie besucht</button>
         <button
           onClick={()=>setSortOldest(s=>!s)}
-          className={`px-3 py-1 rounded-full border-2 border-black ${sortOldest?"bg-black text-white":"bg-white"}`}
+          className={`px-3 py-1 rounded-full ${sortOldest?"bg-black text-white":"bg-white"}`}
         >Am längsten her</button>
       </div>
 
@@ -561,7 +561,7 @@ function StationsPage({ stations, onBack }){
         {sorted.map(st => (
           <div
             key={st.id}
-            className={`p-2 border-2 border-black rounded-lg ${st.visits.length ? 'bg-[#8c4bd6] text-white' : 'bg-white'}`}
+            className={`p-2 border-4 border-black rounded-lg ${st.visits.length ? 'bg-[#8c4bd6] text-white' : 'bg-white'}`}
           >
             <div className="font-bold truncate">{st.name}</div>
             <LineChips lines={st.lines} types={st.types} />
@@ -622,7 +622,7 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
         <div>{sortLabels[sortKey]}</div>
           <button
             onClick={cycleSortKey}
-            className="p-1 rounded-lg border-2 border-black bg-white"
+            className="p-1 rounded-lg bg-white"
             title="Sortierung ändern"
             type="button"
           >
@@ -631,7 +631,7 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
         </div>
       </div>
 
-      {manualOpen ? (<ManualVisitForm stations={unvisited} onAdd={onAddVisit} onCancel={()=>setManualOpen(false)} />) : (<button onClick={()=>setManualOpen(true)} className="w-full px-6 py-4 rounded-2xl text-xl font-black bg-gradient-to-r from-fuchsia-500 via-pink-500 to-orange-400 text-white border-4 border-black shadow-[6px_6px_0_rgba(0,0,0,0.6)] active:translate-y-[2px] active:shadow-[4px_4px_0_rgba(0,0,0,0.6)]">Besuch hinzufügen</button>)}
+      {manualOpen ? (<ManualVisitForm stations={unvisited} onAdd={onAddVisit} onCancel={()=>setManualOpen(false)} />) : (<button onClick={()=>setManualOpen(true)} className="w-full px-6 py-4 rounded-2xl text-xl font-black bg-gradient-to-r from-fuchsia-500 via-pink-500 to-orange-400 text-white">Besuch hinzufügen</button>)}
 
       <div className="mt-4 pr-1 space-y-4">
         {visitedSorted.length===0 ? (<div className="text-sm">Noch keine Besuche eingetragen.</div>) : (
@@ -643,7 +643,7 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
                   <LineChips lines={st.lines} types={st.types} />
                   <div className="text-xs mt-1">Zuletzt am <b>{formatDate(st.visits[st.visits.length-1].date)}</b></div>
                 </div>
-                <div className="shrink-0"><button type="button" onClick={()=>setConfirmId(st.id)} className="w-9 h-9 rounded-full bg-red-500 text-white border-2 border-black flex items-center justify-center" title="Besuch(e) löschen"><Trash2 size={16}/></button></div>
+                <div className="shrink-0"><button type="button" onClick={()=>setConfirmId(st.id)} className="w-9 h-9 rounded-full bg-red-500 text-white flex items-center justify-center" title="Besuch(e) löschen"><Trash2 size={16}/></button></div>
               </div>
               <div className="mt-2 grid grid-cols-1 gap-2">
                 {st.visits.map((v,idx)=> (
@@ -659,8 +659,8 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
                           placeholder="Notiz"
                         />
                         <div className="flex gap-2 justify-end">
-                          <button onClick={cancelEdit} className="px-3 py-1 rounded-lg bg-white border-2 border-black text-xs">Abbrechen</button>
-                          <button onClick={saveEdit} className="px-3 py-1 rounded-lg bg-black text-white border-2 border-black text-xs">Speichern</button>
+                          <button onClick={cancelEdit} className="px-3 py-1 rounded-lg bg-white text-xs">Abbrechen</button>
+                          <button onClick={saveEdit} className="px-3 py-1 rounded-lg bg-black text-white text-xs">Speichern</button>
                         </div>
                       </div>
                     ) : (
@@ -669,7 +669,7 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
                           <div className="flex-1 break-words">{v.note}</div>
                           <button
                             title="Notiz bearbeiten"
-                            className="shrink-0 p-1 rounded-md border-2 border-black bg-white"
+                            className="shrink-0 p-1 rounded-md bg-white"
                             onClick={()=>startEdit(st.id, idx, v.note)}
                           >
                             <Pencil size={14}/>
@@ -677,7 +677,7 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
                         </div>
                       ) : (
                         <button
-                          className="w-full rounded-md border-2 border-dashed border-black px-2 py-1 text-xs bg-white/70 text-left"
+                          className="w-full rounded-md border-dashed px-2 py-1 text-xs bg-white/70 text-left"
                           onClick={()=>startEdit(st.id, idx, "")}
                         >
                           Notiz hinzufügen ✍️
@@ -689,14 +689,14 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
                       {(v.photos || []).map((p,pidx)=> (
                         <button
                           key={pidx}
-                          className="w-full h-64 rounded-xl overflow-hidden border-2 border-black bg-white"
+                          className="w-full h-64 rounded-xl overflow-hidden bg-white"
                           onClick={()=>setZoom({src:p, station:st.name, date:v.date})}
                         >
                           <img src={p} alt="Foto" className="w-full h-full object-contain"/>
                         </button>
                       ))}
                       <button
-                        className="w-full aspect-square rounded-xl border-2 border-dashed border-black flex items-center justify-center bg-white"
+                        className="w-full aspect-square rounded-xl border-dashed flex items-center justify-center bg-white"
                         onClick={()=>{ setPendingPhoto({stationId:st.id, index:idx}); fileRef.current?.click(); }}
                       >
                         <ImageUp size={24}/>
@@ -714,7 +714,7 @@ function VisitedPage({ stations, onBack, onAddVisit, onClearVisits, onAttachPhot
       <Modal open={!!confirmId} onClose={()=>setConfirmId(null)} title="Besuche löschen">
         <div className="space-y-3">
           <p className="text-sm">Diesen Bahnhof als <b>unbesucht</b> markieren? Alle Besuchseinträge werden entfernt.</p>
-          <div className="flex gap-2 justify-end"><button onClick={()=>setConfirmId(null)} className="px-4 py-2 rounded-lg bg-white border-2 border-black">Abbrechen</button><button onClick={()=>{ onClearVisits(confirmId); setConfirmId(null); }} className="px-4 py-2 rounded-lg bg-red-600 text-white border-2 border-black">Löschen</button></div>
+          <div className="flex gap-2 justify-end"><button onClick={()=>setConfirmId(null)} className="px-4 py-2 rounded-lg bg-white">Abbrechen</button><button onClick={()=>{ onClearVisits(confirmId); setConfirmId(null); }} className="px-4 py-2 rounded-lg bg-red-600 text-white">Löschen</button></div>
         </div>
       </Modal>
 
@@ -732,7 +732,7 @@ function ChangePasswordForm({ onSave, onCancel }){
     <div className="space-y-3">
       <div><label className="font-bold text-sm">Altes Passwort</label><input type="password" value={oldPw} onChange={e=>setOldPw(e.target.value)} className="w-full mt-1 px-3 py-2 rounded-lg border-4 border-black bg-white"/></div>
       <div><label className="font-bold text-sm">Neues Passwort</label><input type="password" value={newPw} onChange={e=>setNewPw(e.target.value)} className="w-full mt-1 px-3 py-2 rounded-lg border-4 border-black bg-white"/></div>
-      <div className="flex gap-2 justify-end"><button onClick={onCancel} className="px-4 py-2 rounded-lg bg-white border-2 border-black">Abbrechen</button><button onClick={()=>onSave(oldPw, newPw)} className="px-4 py-2 rounded-lg bg-black text-white border-2 border-black">Speichern</button></div>
+      <div className="flex gap-2 justify-end"><button onClick={onCancel} className="px-4 py-2 rounded-lg bg-white">Abbrechen</button><button onClick={()=>onSave(oldPw, newPw)} className="px-4 py-2 rounded-lg bg-black text-white">Speichern</button></div>
     </div>
   );
 }

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -25,8 +25,8 @@ export default function Login({ onSuccess }){
       <div><input value={username} onChange={e=>setUsername(e.target.value)} placeholder="Username" className="w-full border p-2"/></div>
       <div><input type="password" value={password} onChange={e=>setPassword(e.target.value)} placeholder="Password" className="w-full border p-2"/></div>
       {error && <div className="text-red-600 text-sm">{error}</div>}
-      <button type="submit" className="w-full bg-black text-white p-2 rounded">{mode==='login'? 'Login' : 'Registrieren'}</button>
-      <button type="button" className="text-sm underline" onClick={()=>setMode(mode==='login'?'register':'login')}>
+      <button type="submit" className="w-full bg-black text-white p-2 rounded-lg">{mode==='login'? 'Login' : 'Registrieren'}</button>
+      <button type="button" className="w-full px-2 py-1 rounded-lg bg-white text-sm" onClick={()=>setMode(mode==='login'?'register':'login')}>
         {mode==='login' ? 'Neu hier? Registrieren' : 'Schon registriert? Login'}
       </button>
     </form>

--- a/src/components/ComboBox.jsx
+++ b/src/components/ComboBox.jsx
@@ -43,7 +43,11 @@ export default function ComboBox({ options, value, onChange, placeholder = "Bahn
         placeholder={placeholder}
         className="w-full px-3 py-2 rounded-lg border-4 border-black bg-white"
       />
-      <button type="button" onClick={() => setOpen(o => !o)} className="absolute right-2 top-1/2 -translate-y-1/2 px-2 py-1 rounded border-2 border-black bg-white">▾</button>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="absolute right-2 top-1/2 -translate-y-1/2 px-2 py-1 rounded bg-white"
+      >▾</button>
       {open && (
         <div className="absolute z-20 mt-1 left-0 right-0 max-h-64 overflow-auto rounded-lg border-4 border-black bg-white shadow">
           {filtered.length === 0 ? (

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -9,7 +9,7 @@ export default function Modal({ open, onClose, title, children }){
       <div className="relative w-[96%] max-w-[860px] md:w-[760px] rounded-3xl shadow-2xl border-4 border-black p-4 md:p-6 bg-gradient-to-br from-yellow-300 via-fuchsia-200 to-cyan-200">
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-2xl md:text-3xl font-extrabold tracking-tight text-black drop-shadow">{title}</h2>
-          <button onClick={onClose} className="p-2 rounded-full bg-black text-white"><X size={18}/></button>
+          <button onClick={onClose} className="p-2 rounded-full bg-black text-white border-4 border-black"><X size={18}/></button>
         </div>
         <div className="max-h-[85vh] md:max-h-[72vh] overflow-auto pr-1">{children}</div>
       </div>

--- a/src/components/ZoomBox.jsx
+++ b/src/components/ZoomBox.jsx
@@ -13,7 +13,11 @@ export default function ZoomBox({ src }){
   const reset = () => { setScale(1); setPos({x:0,y:0}); };
   return (
     <div className="relative w-full h-[70vh] bg-white rounded-xl border-4 border-black overflow-hidden">
-      <div className="absolute top-2 right-2 z-10 flex gap-2"><button onClick={() => setScale(s=>Math.min(5,s*1.1))} className="px-3 py-1 rounded-lg border-2 border-black bg-white">+</button><button onClick={() => setScale(s=>Math.max(1,s/1.1))} className="px-3 py-1 rounded-lg border-2 border-black bg-white">-</button><button onClick={reset} className="px-3 py-1 rounded-lg border-2 border-black bg-white">Reset</button></div>
+      <div className="absolute top-2 right-2 z-10 flex gap-2">
+        <button onClick={() => setScale(s=>Math.min(5,s*1.1))} className="px-3 py-1 rounded-lg bg-white">+</button>
+        <button onClick={() => setScale(s=>Math.max(1,s/1.1))} className="px-3 py-1 rounded-lg bg-white">-</button>
+        <button onClick={reset} className="px-3 py-1 rounded-lg bg-white">Reset</button>
+      </div>
       <div ref={wrapRef} onWheel={onWheel} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} className="w-full h-full flex items-center justify-center touch-none cursor-grab active:cursor-grabbing">
         <img src={src} alt="Zoom" style={{ transform:`translate(${pos.x}px, ${pos.y}px) scale(${scale})` }} className="max-w-none max-h-none" />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,7 @@
 @import "tailwindcss";
+
+@layer base {
+  button {
+    @apply border-4 border-black shadow-[4px_4px_0_rgba(0,0,0,0.6)] active:shadow-[2px_2px_0_rgba(0,0,0,0.6)] active:translate-y-[2px];
+  }
+}


### PR DESCRIPTION
## Summary
- add global 90s-style button design with thick borders and drop shadows
- align buttons across app to use unified style
- refresh login and various controls for consistent feel

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook useEffect has a missing dependency: 'updateStations')*


------
https://chatgpt.com/codex/tasks/task_e_689a387fe8dc832d958e0349b9f2da23