### PR TITLE
Use only home station for travel times and log API errors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,7 +98,6 @@ export default function App(){
   const [showMilestones, setShowMilestones] = useState(false);
   const [cooldownEnabled, setCooldownEnabled] = useState(()=>{ try{ return JSON.parse(localStorage.getItem(COOLDOWN_KEY) ?? "true"); }catch{ return true; }});
   const [homeStation, setHomeStation] = useState(()=>{ try{ return localStorage.getItem(HOME_KEY) || ""; }catch{ return ""; }});
-  const [coords, setCoords] = useState(null);
 
   const stationLabelFromName = (name) => {
     const n = normName(name);
@@ -137,19 +136,12 @@ export default function App(){
     }
   }, [homeStation]);
   useEffect(()=>{
-    if (typeof navigator !== 'undefined' && navigator.geolocation){
-      navigator.geolocation.getCurrentPosition(pos=>{
-        setCoords({lat:pos.coords.latitude, lon:pos.coords.longitude});
-      }, ()=>{});
-    }
-  }, []);
-  useEffect(()=>{
     if (token) {
       fetchData(token).then(data=>{ if(data) updateStations(normalizeStations(data)); }).catch(()=>setToken(null));
     }
   }, [token, updateStations]);
   const visitedIds = useMemo(()=> new Set(stations.filter(s=>s.visits.length>0).map(s=>s.id)), [stations]);
-  const origin = coords ? `${coords.lat},${coords.lon}` : (homeStation.trim() ? stationLabelFromName(homeStation.trim()) : null);
+  const origin = homeStation.trim() ? stationLabelFromName(homeStation.trim()) : null;
   const rolledStations = rolled.map(id=>stations.find(s=>s.id===id)).filter(Boolean);
   const visitedCount = visitedIds.size, total = stations.length||1, percent = Math.round((visitedCount/total)*100);
   const lastVisitDate = useMemo(()=>{ let max=""; stations.forEach(s=> s.visits.forEach(v=>{ if((v.date||"")>max) max=v.date; })); return max; }, [stations]);

--- a/src/journeys.js
+++ b/src/journeys.js
@@ -8,7 +8,11 @@ async function resolve(loc){
   if(cache.has(loc)) return cache.get(loc);
   const url = `https://v5.vbb.transport.rest/locations?query=${encodeURIComponent(loc)}&results=1`;
   const res = await fetch(url);
-  if(!res.ok) return null;
+  if(!res.ok){
+    const text = await res.text().catch(()=>"{}");
+    console.error('resolve locations error', res.status, text);
+    return null;
+  }
   const data = await res.json().catch(()=>null);
   const id = data?.[0]?.id;
   if(id) cache.set(loc, id);
@@ -20,7 +24,11 @@ export async function fetchJourneyDuration(from, to){
   if(!fromId || !toId) return null;
   const url = `https://v5.vbb.transport.rest/journeys?from=${encodeURIComponent(fromId)}&to=${encodeURIComponent(toId)}&results=1&language=de`;
   const res = await fetch(url);
-  if (!res.ok) return null;
+  if (!res.ok){
+    const text = await res.text().catch(()=>"{}");
+    console.error('journeys error', res.status, text);
+    return null;
+  }
   const data = await res.json().catch(()=>null);
   const journey = data?.journeys?.[0];
   if (!journey || !Array.isArray(journey.legs) || journey.legs.length === 0) return null;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -12,7 +12,7 @@
   "settings.import": "Import",
   "settings.homeStation": "Home-Station",
   "settings.homeStation.placeholder": "z.B. Berlin Hbf",
-  "settings.homeStation.hint": "Für Fahrzeiten, falls Standort nicht verfügbar.",
+  "settings.homeStation.hint": "Für die Berechnung der Fahrzeiten.",
   "settings.cooldown": "Würfel-Cooldown",
   "settings.cooldown.label": "20-Sekunden-Cooldown aktiv",
   "settings.cooldown.desc": "Deaktivieren, um ohne „srsly?“-Hinweis schnell zu würfeln.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,7 +12,7 @@
   "settings.import": "Import",
   "settings.homeStation": "Home Station",
   "settings.homeStation.placeholder": "e.g. Berlin Central",
-  "settings.homeStation.hint": "Used for travel times if location is unavailable.",
+  "settings.homeStation.hint": "Used to calculate travel times.",
   "settings.cooldown": "Dice Cooldown",
   "settings.cooldown.label": "20-second cooldown enabled",
   "settings.cooldown.desc": "Disable to roll quickly without the “srsly?” notice.",


### PR DESCRIPTION
## Summary
- Drop browser geolocation and derive origin solely from configured home station
- Show API response when journey queries fail for easier debugging
- Clarify home station help text

## Testing
- `npm test` *(fails: TypeError: __vite_ssr_import_1__ is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a53a72860832d9bf0dd8998fc3cd5