### PR TITLE
Show username in account settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,6 +84,7 @@ const normName = (s) => String(s||"")
 export default function App(){
   const { t, lang, setLang } = useI18n();
   const [token, setToken] = useState(()=>localStorage.getItem('authToken'));
+  const [username, setUsername] = useState(()=>localStorage.getItem('authUsername') || "");
   const [stations, setStations] = useState/** @type {Station[]} */(()=>{ try{ const raw=localStorage.getItem(STORAGE_KEY); if(raw) return normalizeStations(JSON.parse(raw));}catch{ /* ignore */ } return makeSeed(); });
   const [page, setPage] = useState/** @type {"home"|"visited"|"stations"} */("home");
   const [rolled, setRolled] = useState/** @type {string[]} */([]);
@@ -166,10 +167,12 @@ export default function App(){
   }, [stations]);
   const photoCount = useMemo(()=> stations.reduce((acc,s)=> acc + s.visits.reduce((sum,v)=> sum + (v.photos?.length||0),0),0), [stations]);
 
-  function handleLogin(tok){
+  function handleLogin(tok, user){
     try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
     setStations(makeSeed());
     setToken(tok);
+    setUsername(user);
+    try { localStorage.setItem('authUsername', user); } catch { /* ignore */ }
   }
   async function handleLogout(){
     const current = token;
@@ -177,6 +180,8 @@ export default function App(){
     try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
     setStations(makeSeed());
     setToken(null);
+    setUsername("");
+    try { localStorage.removeItem('authUsername'); } catch { /* ignore */ }
   }
   async function confirmDeleteAccount(){
     if(!token) return;
@@ -191,6 +196,8 @@ export default function App(){
     try { await apiLogout(token); } catch { /* ignore */ }
     setShowDeleteAccount(false);
     setToken(null);
+    setUsername("");
+    try { localStorage.removeItem('authUsername'); } catch { /* ignore */ }
   }
 
   async function submitChangePassword(oldPw, newPw){
@@ -418,6 +425,7 @@ export default function App(){
           </div>
           <div className="mt-4 rounded-2xl border-4 border-black p-4 bg-white/80">
             <h3 className="font-extrabold text-lg mb-2">{t('settings.account')}</h3>
+            {username && (<div className="mb-2 text-sm">{t('settings.account.loggedInAs')} <b>{username}</b></div>)}
             <div className="flex flex-col sm:flex-row gap-2 w-full">
               <button
                 onClick={()=>setShowChangePassword(true)}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -20,6 +20,7 @@
   "settings.account.changePassword": "Passwort ändern",
   "settings.account.delete": "Konto löschen",
   "settings.account.logout": "Logout",
+  "settings.account.loggedInAs": "Angemeldet als",
   "settings.language": "Sprache",
   "settings.language.de": "Deutsch",
   "settings.language.en": "Englisch",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -20,6 +20,7 @@
   "settings.account.changePassword": "Change Password",
   "settings.account.delete": "Delete Account",
   "settings.account.logout": "Logout",
+  "settings.account.loggedInAs": "Logged in as",
   "settings.language": "Language",
   "settings.language.de": "German",
   "settings.language.en": "English",

--- a/tests/password.test.js
+++ b/tests/password.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import * as register from '../functions/api/register.js';
-import * as login from '../functions/api/login.js';
-import * as password from '../functions/api/password.js';
+import { onRequestPost as register } from '../functions/api/register.js';
+import { onRequestPost as login } from '../functions/api/login.js';
+import { onRequestPost as password } from '../functions/api/password.js';
 
 function makeEnv(){
   const store = {};
@@ -32,20 +32,20 @@ beforeEach(() => {
 
 describe('password change', () => {
   it('changes password and rejects old password', async () => {
-    let res = await register(makeRequest('/api/register', 'POST', { username: 'alice', password: 'oldpw' }), env);
+    let res = await register({ request: makeRequest('/api/register', 'POST', { username: 'alice', password: 'oldpw' }), env });
     expect(res.status).toBe(200);
 
-    res = await login(makeRequest('/api/login', 'POST', { username: 'alice', password: 'oldpw' }), env);
+    res = await login({ request: makeRequest('/api/login', 'POST', { username: 'alice', password: 'oldpw' }), env });
     expect(res.status).toBe(200);
     const { token } = await res.json();
 
-    res = await password(makeRequest('/api/password', 'POST', { oldPassword: 'oldpw', newPassword: 'newpw' }, token), env);
+    res = await password({ request: makeRequest('/api/password', 'POST', { oldPassword: 'oldpw', newPassword: 'newpw' }, token), env });
     expect(res.status).toBe(200);
 
-    res = await login(makeRequest('/api/login', 'POST', { username: 'alice', password: 'newpw' }), env);
+    res = await login({ request: makeRequest('/api/login', 'POST', { username: 'alice', password: 'newpw' }), env });
     expect(res.status).toBe(200);
 
-    res = await login(makeRequest('/api/login', 'POST', { username: 'alice', password: 'oldpw' }), env);
+    res = await login({ request: makeRequest('/api/login', 'POST', { username: 'alice', password: 'oldpw' }), env });
     expect(res.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary
- Persist the signed-in username and show it under the **Konto** heading in settings.
- Add translations for the "Logged in as" label.
- Adjust password-change test to use API handlers directly.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5dee0c3c832d91f0582620387bbc