### PR TITLE
Show transfer count and clean station labels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,16 @@ const HOME_KEY = "zufallstour3000.homeStation";
 /** @typedef {{ id:string; name:string; types:("S"|"U"|"R")[]; lines?: string[]; visits: Visit[] }} Station */
 /** @typedef {{ date: string; note?: string; photos?: string[] }} Visit */
 const uid = () => Math.random().toString(36).slice(2, 10);
-export const googleMapsUrl = (name) => `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name + ", Berlin")}`;
+const stripRegionalPrefix = (name) => {
+  const match = /^([A-Z+]+)\s+(.*)$/.exec(name);
+  if (!match) return name;
+  const types = match[1].split('+').filter(t => t !== 'R');
+  return (types.length ? types.join('+') + ' ' : '') + match[2];
+};
+export const googleMapsUrl = (name) => {
+  const clean = stripRegionalPrefix(name);
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(clean + ", Berlin")}`;
+};
 export const stationLabel = (st) => {
   const prefix = Array.isArray(st?.types) && st.types.length
     ? [...st.types].sort().join('+')
@@ -473,12 +482,12 @@ function StationRow({ st, origin, onAddVisit, onUnvisit }){
   const { t } = useI18n();
   const isVisited = st.visits.length>0; const lastVisit = isVisited ? st.visits[st.visits.length-1] : null;
   const label = stationLabel(st);
-  const [duration, setDuration] = useState(null);
+  const [journey, setJourney] = useState(null);
   useEffect(()=>{
     let cancelled = false;
-    if (!origin){ setDuration(null); return; }
+    if (!origin){ setJourney(null); return; }
     fetchJourneyDuration(origin, label).then(d=>{
-      if(!cancelled) setDuration(d);
+      if(!cancelled) setJourney(d);
     }).catch(()=>{});
     return ()=>{ cancelled = true; };
   }, [origin, label]);
@@ -488,7 +497,7 @@ function StationRow({ st, origin, onAddVisit, onUnvisit }){
         <div className="flex-1 min-w-0">
           <div className="font-extrabold text-lg leading-tight truncate flex items-baseline gap-2">
             <span className="truncate">{label}</span>
-            <span className="text-xs font-normal opacity-90 whitespace-nowrap">{duration!=null ? `≈ ${duration} min` : 'n/a'}</span>
+            <span className="text-xs font-normal opacity-90 whitespace-nowrap">{journey?.minutes!=null ? `Anreise ≈ ${journey.minutes} min${journey.transfers!=null ? `, ${journey.transfers}x umsteigen` : ''}` : 'n/a'}</span>
           </div>
           <div className="text-xs opacity-90 flex flex-col gap-1">
             {isVisited ? (<span>{t('station.visitedOn')} <b>{formatDate(lastVisit.date)}</b></span>) : (<span>{t('station.notVisited')}</span>)}

--- a/src/journeys.js
+++ b/src/journeys.js
@@ -1,12 +1,20 @@
 // Cache resolved location ids so we don't hit the /locations endpoint repeatedly
 const cache = new Map();
 
+function stripRegionalPrefix(name) {
+  const match = /^([A-Z+]+)\s+(.*)$/.exec(name);
+  if (!match) return name;
+  const types = match[1].split('+').filter(t => t !== 'R');
+  return (types.length ? types.join('+') + ' ' : '') + match[2];
+}
+
 async function resolve(loc){
   if(!loc) return null;
   // Coordinates or already an id
   if(/^\d{6,}$/.test(loc) || /^-?\d+(?:\.\d+)?,-?\d+(?:\.\d+)?$/.test(loc)) return loc;
-  if(cache.has(loc)) return cache.get(loc);
-  const url = `https://v5.vbb.transport.rest/locations?query=${encodeURIComponent(loc)}&results=1`;
+  const query = stripRegionalPrefix(loc);
+  if(cache.has(query)) return cache.get(query);
+  const url = `https://v5.vbb.transport.rest/locations?query=${encodeURIComponent(query)}&results=1`;
   const res = await fetch(url);
   if(!res.ok){
     const text = await res.text().catch(()=>"{}");
@@ -15,7 +23,7 @@ async function resolve(loc){
   }
   const data = await res.json().catch(()=>null);
   const id = data?.[0]?.id;
-  if(id) cache.set(loc, id);
+  if(id) cache.set(query, id);
   return id || null;
 }
 
@@ -36,7 +44,8 @@ export async function fetchJourneyDuration(from, to){
     const departure = new Date(journey.legs[0].departure);
     const arrival = new Date(journey.legs[journey.legs.length - 1].arrival);
     const diff = Math.round((arrival - departure) / 60000);
-    return isFinite(diff) ? diff : null;
+    const transfers = Number.isInteger(journey.transfers) ? journey.transfers : null;
+    return isFinite(diff) ? { minutes: diff, transfers } : null;
   } catch {
     return null;
   }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -15,6 +15,10 @@ describe('utility functions', () => {
 
     const g2 = googleMapsUrl('Frankfurter Allee');
     expect(g2).toContain('Frankfurter%20Allee');
+
+    const g3 = googleMapsUrl('R+S+U Berlin Hbf');
+    expect(g3).toContain('S%2BU%20Berlin%20Hbf');
+    expect(g3).not.toContain('R%');
   });
 
   it('prefixes station names with their types', () => {


### PR DESCRIPTION
## Summary
- Include transfer count in journey duration if provided by API
- Strip regional "R" prefix from station labels for lookups and Google Maps links
- Add test ensuring Google Maps URLs omit regional prefix

## Testing
- `npm test` *(fails: TypeError __vite_ssr_import_1__ is not a function)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a60337e94832da5c69d37a0032bf0