### PR TITLE
Compress uploaded photos before saving

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import ZoomBox from "./components/ZoomBox";
 import Login from "./Login";
 import { fetchData, saveData, logout as apiLogout, deleteAccount, changePassword } from "./api.js";
 import { useI18n } from "./i18n.jsx";
+import { fileToDataUrl } from "./imageUtils.js";
 
 // Helpers & Types
 const STORAGE_KEY = "zufallstour3000.v4";
@@ -40,7 +41,6 @@ const downloadFile = (filename, text, mime = "application/json;charset=utf-8") =
     window.open(url, "_blank"); setTimeout(()=>URL.revokeObjectURL(url), 10000);
   }
 };
-const fileToDataUrl = (file) => new Promise((res, rej)=>{ const r=new FileReader(); r.onload=()=>res(r.result); r.onerror=rej; r.readAsDataURL(file); });
 export const makeDataUrl = (text, mime="application/json;charset=utf-8") => URL.createObjectURL(new Blob([text], {type:mime}));
 export const pickThreeUnvisited = (stations/**:Station[]*/)=>{ const unvisited=stations.filter(s=>(s.visits?.length||0)===0); if(!unvisited.length) return []; const pool=[...unvisited]; for(let i=pool.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [pool[i],pool[j]]=[pool[j],pool[i]];} return pool.slice(0,Math.min(3,pool.length)).map(s=>s.id); };
 export const rollAllowed = (lastTs, now=Date.now()) => !lastTs || (now-lastTs)>=20000;

--- a/src/components/ManualVisitForm.jsx
+++ b/src/components/ManualVisitForm.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Camera } from "lucide-react";
 import ComboBox from "./ComboBox";
 import { useI18n } from "../i18n.jsx";
-
-const fileToDataUrl = (file) => new Promise((res, rej)=>{ const r=new FileReader(); r.onload=()=>res(r.result); r.onerror=rej; r.readAsDataURL(file); });
+import { fileToDataUrl } from "../imageUtils.js";
 
 export default function ManualVisitForm({ stations, onAdd, onCancel }){
   const { t } = useI18n();

--- a/src/imageUtils.js
+++ b/src/imageUtils.js
@@ -1,0 +1,61 @@
+export async function fileToDataUrl(file, options = {}) {
+  const {
+    maxSize = 1600,
+    mimeType = 'image/webp',
+    quality = 0.8,
+  } = options;
+
+  // Fallback: simple data URL if anything fails
+  async function fallback() {
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+
+  try {
+    const img = await new Promise((resolve, reject) => {
+      const url = URL.createObjectURL(file);
+      const image = new Image();
+      image.onload = () => {
+        URL.revokeObjectURL(url);
+        resolve(image);
+      };
+      image.onerror = () => {
+        URL.revokeObjectURL(url);
+        reject(new Error('Image load error'));
+      };
+      image.src = url;
+    });
+
+    let { width, height } = img;
+    if (width > height && width > maxSize) {
+      height = Math.round((height * maxSize) / width);
+      width = maxSize;
+    } else if (height > maxSize) {
+      width = Math.round((width * maxSize) / height);
+      height = maxSize;
+    }
+
+    const canvas = typeof OffscreenCanvas !== 'undefined'
+      ? new OffscreenCanvas(width, height)
+      : Object.assign(document.createElement('canvas'), { width, height });
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0, width, height);
+
+    const blob = canvas.convertToBlob
+      ? await canvas.convertToBlob({ type: mimeType, quality })
+      : await new Promise((resolve) => canvas.toBlob(resolve, mimeType, quality));
+
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return fallback();
+  }
+}


### PR DESCRIPTION
## Summary
- Add `fileToDataUrl` utility that resizes images and exports them as WebP to keep file sizes small.
- Use new compression utility in main app and manual visit form to ensure photos are reduced before saving.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a61262050832d837d6c5873b2533d