### PR TITLE
Add help section with external content

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil, ImageUp, KeyRound, LogOut, ArrowUp } from "lucide-react";
+import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil, ImageUp, KeyRound, LogOut, ArrowUp, HelpCircle } from "lucide-react";
 import { fetchJourneyDuration } from "./journeys";
 import { seedStations } from "./seed_stations";
 import HeaderLogo from "./components/HeaderLogo";
@@ -13,6 +13,8 @@ import Login from "./Login";
 import { fetchData, saveData, logout as apiLogout, deleteAccount, changePassword } from "./api.js";
 import { useI18n } from "./i18n.jsx";
 import { fileToDataUrl } from "./imageUtils.js";
+import helpDe from "./help.de.html?raw";
+import helpEn from "./help.en.html?raw";
 
 // Helpers & Types
 const STORAGE_KEY = "zufallstour3000.v4";
@@ -98,6 +100,7 @@ export default function App(){
   const [page, setPage] = useState/** @type {"home"|"visited"|"stations"} */("home");
   const [rolled, setRolled] = useState/** @type {string[]} */([]);
   const [showSettings, setShowSettings] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [addVisitFor, setAddVisitFor] = useState/** @type {Station|null} */(null);
   const [exportDialog, setExportDialog] = useState({open:false, href:"", filename:"", text:""});
   const [showDeleteAccount, setShowDeleteAccount] = useState(false);
@@ -109,6 +112,7 @@ export default function App(){
   const [cooldownEnabled, setCooldownEnabled] = useState(()=>{ try{ return JSON.parse(localStorage.getItem(COOLDOWN_KEY) ?? "true"); }catch{ return true; }});
   const [homeStation, setHomeStation] = useState(()=>{ try{ return localStorage.getItem(HOME_KEY) || ""; }catch{ return ""; }});
   const [showScrollTop, setShowScrollTop] = useState(false);
+  const helpHtml = lang === "de" ? helpDe : helpEn;
 
   const stationLabelFromName = (name) => {
     const n = normName(name);
@@ -378,6 +382,8 @@ export default function App(){
             </button>
             <button onClick={()=>setPage('visited')} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 hover:brightness-110">{t('nav.visited')}</button>
             <button onClick={()=>setPage('stations')} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 hover:brightness-110">{t('nav.allStations')}</button>
+            <div className="hidden md:block" />
+            <button onClick={()=>setShowHelp(true)} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-white text-black flex items-center gap-2 hover:brightness-110"><HelpCircle size={20}/> {t('nav.help')}</button>
             <button onClick={()=>setShowSettings(true)} className="w-full justify-center px-4 py-3 rounded-full font-bold bg-black text-white flex items-center" aria-label={t('nav.settings')} title={t('nav.settings')}><SettingsIcon size={20}/></button>
           </div>
 
@@ -401,6 +407,9 @@ export default function App(){
           <StationsPage stations={stations} onBack={()=>setPage('home')} />
         )}
 
+        <Modal open={showHelp} onClose={()=>setShowHelp(false)} title={t('help.title')}>
+          <div className="text-sm" dangerouslySetInnerHTML={{__html: helpHtml}} />
+        </Modal>
         <Modal open={showSettings} onClose={()=>setShowSettings(false)} title={t('settings.title')}>
           <div className="rounded-2xl border-4 border-black p-4 bg-white/80">
             <h3 className="font-extrabold text-lg mb-2">{t('settings.language')}</h3>

--- a/src/help.de.html
+++ b/src/help.de.html
@@ -1,0 +1,22 @@
+<h2>Willkommen bei Zufallstour 3000</h2>
+<p>Mit dieser App entdeckst du Berlins Nahverkehr zufällig. Die wichtigsten Bereiche werden hier erklärt.</p>
+
+<h3>Start – Station würfeln</h3>
+<p>Drücke auf <strong>WÜRFELN</strong> oder schüttle dein Telefon, um eine zufällige Station zu erhalten. Ein 20‑Sekunden‑Cooldown verhindert versehentliche Doppeldrehungen. In den Einstellungen kannst du ihn deaktivieren.</p>
+
+<h3>Stationsansicht</h3>
+<p>Nach dem Würfeln siehst du Details zur Station: welche Linien dort halten und deine bisherigen Besuche. Markiere die Station als besucht, füge Notizen oder Fotos hinzu. Besuche lassen sich später bearbeiten oder löschen.</p>
+
+<h3>Besuchte Stationen</h3>
+<p>Im Reiter <strong>Besuchte Stationen</strong> findest du alle bereits abgehakten Orte. Sortiere die Liste nach Name oder Datum, um deinen Fortschritt zu verfolgen.</p>
+
+<h3>Alle Stationen</h3>
+<p>Die Ansicht <strong>Alle Stationen</strong> zeigt das vollständige Netz. Über die Suche kannst du Stationen finden und Besuche manuell hinzufügen.</p>
+
+<h3>Backups</h3>
+<p>Deine Daten werden nur lokal im Browser gespeichert. Über <strong>Einstellungen → Backups</strong> kannst du sie als JSON-Datei exportieren oder eine frühere Sicherung importieren, damit nichts verloren geht.</p>
+
+<h3>Einstellungen & Konto</h3>
+<p>Hier kannst du die Sprache wechseln, eine Heimatstation festlegen, den Würfel-Cooldown steuern und dein Konto verwalten (Passwort ändern, abmelden oder Konto löschen).</p>
+
+<p>Viel Spaß auf deiner Zufallstour durch Berlin!</p>

--- a/src/help.en.html
+++ b/src/help.en.html
@@ -1,0 +1,22 @@
+<h2>Welcome to Random Tour 3000</h2>
+<p>This app lets you explore Berlin's public transport stations at random. The main areas of the app are explained below.</p>
+
+<h3>Home – Roll a station</h3>
+<p>Press the <strong>ROLL</strong> button or shake your phone to draw a random station. A 20 second cooldown avoids accidental double rolls. Disable it under settings if you prefer instant rolls.</p>
+
+<h3>Station view</h3>
+<p>After rolling you see details about the station: served lines and your visit history. Mark the station as visited, add notes or attach photos. Visits can be edited or removed later.</p>
+
+<h3>Visited</h3>
+<p>The <strong>Visited Stations</strong> tab lists every place you have checked off so far. Sort the list by name or by date to review your progress.</p>
+
+<h3>All stations</h3>
+<p>The <strong>All Stations</strong> view shows the complete network. Use the search to find places manually and add visits that were not rolled.</p>
+
+<h3>Backups</h3>
+<p>Your data is stored only in the browser. Use <strong>Settings → Backups</strong> to export a JSON file or import a previous backup so nothing gets lost.</p>
+
+<h3>Settings & account</h3>
+<p>Change the language, define a home station for travel time calculations, toggle the roll cooldown and manage your account (change password, log out or delete account).</p>
+
+<p>Enjoy your random tour through Berlin!</p>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3,6 +3,8 @@
   "nav.visited": "Besuchte Bahnhöfe",
   "nav.allStations": "Alle Bahnhöfe",
   "nav.settings": "Einstellungen",
+  "nav.help": "Hilfe",
+  "help.title": "Hilfe",
   "home.noRoll": "Noch nichts ausgewürfelt … drück auf {{roll}}! ✨",
   "roll": "WÜRFELN",
   "settings.title": "Einstellungen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,6 +3,8 @@
   "nav.visited": "Visited Stations",
   "nav.allStations": "All Stations",
   "nav.settings": "Settings",
+  "nav.help": "Help",
+  "help.title": "Help",
   "home.noRoll": "Nothing rolled yet… press {{roll}}! ✨",
   "roll": "ROLL",
   "settings.title": "Settings",


### PR DESCRIPTION
## Summary
- add help button next to settings
- show help modal using separate HTML files per language
- expand help articles with detailed sections for each app area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b16f7aa74832dae77eb27fed9f89c