### PR TITLE
Add profile share link and profile endpoint test

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,6 +188,7 @@ export default function App(){
     return stats;
   }, [stations]);
   const photoCount = useMemo(()=> stations.reduce((acc,s)=> acc + s.visits.reduce((sum,v)=> sum + (v.photos?.length||0),0),0), [stations]);
+  const profileUrl = useMemo(() => username ? `${window.location.origin}/profile/${encodeURIComponent(username)}` : '', [username]);
 
   function handleLogin(tok, user){
     try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
@@ -479,11 +480,11 @@ export default function App(){
                     <input
                       type="text"
                       readOnly
-                      value={`${window.location.origin}/profile/${encodeURIComponent(username)}`}
+                      value={profileUrl}
                       className="flex-1 px-3 py-2 rounded-lg border-4 border-black bg-white text-xs"
                     />
                     <button
-                      onClick={()=>navigator.clipboard.writeText(`${window.location.origin}/profile/${encodeURIComponent(username)}`)}
+                      onClick={()=>navigator.clipboard.writeText(profileUrl)}
                       className="px-3 py-2 rounded-lg border-4 border-black bg-blue-500 text-white text-xs font-bold"
                     >{t('settings.account.copy')}</button>
                   </div>

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -49,4 +49,11 @@ describe('profile endpoint', () => {
     expect(body.username).toBe('bob');
     expect(body.data).toEqual(sampleData);
   });
+
+  it('returns 404 for an unknown username', async () => {
+    const res = await profileGet({ env, params: { username: 'alice' } });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('notfound');
+  });
 });


### PR DESCRIPTION
## Summary
- Factor out memoized `profileUrl` and enable copying from settings
- Verify profile API returns 404 for unknown usernames

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9db6ea34832dac5e15d8815d8047