### PR TITLE
fix: restore backend utils for functions deployment

### DIFF
--- a/functions/_utils.js
+++ b/functions/_utils.js
@@ -1,0 +1,46 @@
+export async function getDb(env){
+  const data = await env.DB.get('db');
+  return data ? JSON.parse(data) : { users: [], data: {}, sessions: {} };
+}
+
+export async function saveDb(env, db){
+  await env.DB.put('db', JSON.stringify(db));
+}
+
+export async function parseBody(request){
+  try {
+    return await request.json();
+  } catch {
+    return {};
+  }
+}
+
+export async function hashPassword(password){
+  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+  const saltHex = Array.from(saltBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+  const data = new TextEncoder().encode(saltHex + password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashHex = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `${saltHex}:${hashHex}`;
+}
+
+export async function verifyPassword(password, stored){
+  const [saltHex, hashHex] = stored.split(':');
+  const data = new TextEncoder().encode(saltHex + password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const computed = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return hashHex === computed;
+}
+
+export function auth(request, db){
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader) return null;
+  const token = authHeader.split(' ')[1];
+  const uid = db.sessions[token];
+  return uid ? { id: uid } : null;
+}
+
+export function randomHex(bytes){
+  const arr = crypto.getRandomValues(new Uint8Array(bytes));
+  return Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/functions/api/account.js
+++ b/functions/api/account.js
@@ -1,4 +1,4 @@
-import { getDb, saveDb, auth } from '../../src/utils.js';
+import { getDb, saveDb, auth } from '../_utils.js';
 
 export const onRequestDelete = async ({ request, env }) => {
   const db = await getDb(env);

--- a/functions/api/data.js
+++ b/functions/api/data.js
@@ -1,4 +1,4 @@
-import { getDb, saveDb, parseBody, auth } from '../../src/utils.js';
+import { getDb, saveDb, parseBody, auth } from '../_utils.js';
 
 export const onRequestGet = async ({ request, env }) => {
   const db = await getDb(env);

--- a/functions/api/login.js
+++ b/functions/api/login.js
@@ -1,4 +1,4 @@
-import { getDb, saveDb, parseBody, verifyPassword, randomHex } from '../../src/utils.js';
+import { getDb, saveDb, parseBody, verifyPassword, randomHex } from '../_utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
   const { username, password } = await parseBody(request);

--- a/functions/api/logout.js
+++ b/functions/api/logout.js
@@ -1,4 +1,4 @@
-import { getDb, saveDb } from '../../src/utils.js';
+import { getDb, saveDb } from '../_utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
   const db = await getDb(env);

--- a/functions/api/password.js
+++ b/functions/api/password.js
@@ -1,4 +1,4 @@
-import { getDb, saveDb, parseBody, auth, hashPassword, verifyPassword } from '../../src/utils.js';
+import { getDb, saveDb, parseBody, auth, hashPassword, verifyPassword } from '../_utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
   const db = await getDb(env);

--- a/functions/api/profile/[username].js
+++ b/functions/api/profile/[username].js
@@ -1,4 +1,4 @@
-import { getDb } from '../../../src/utils.js';
+import { getDb } from '../../_utils.js';
 
 export const onRequestGet = async ({ env, params }) => {
   const db = await getDb(env);

--- a/functions/api/register.js
+++ b/functions/api/register.js
@@ -1,4 +1,4 @@
-import { getDb, saveDb, parseBody, hashPassword } from '../../src/utils.js';
+import { getDb, saveDb, parseBody, hashPassword } from '../_utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
   const { username, password } = await parseBody(request);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "lucide-react": "^0.539.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1",
-        "wrangler": "^4.28.1"
+        "react-dom": "^19.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -5208,10 +5207,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wrangler": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.28.1.tgz"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,13 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "deploy": "wrangler deploy --config wrangler.toml --env production",
-    "deploy:preview": "wrangler deploy --config wrangler.toml --env preview"
+    "deploy": "npx wrangler deploy --config wrangler.toml --env production",
+    "deploy:preview": "npx wrangler deploy --config wrangler.toml --env preview"
   },
   "dependencies": {
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "wrangler": "^4.28.1"
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/worker.js
+++ b/src/worker.js
@@ -7,7 +7,7 @@ import { dataGet, dataPost } from './api/data.js';
 import { profileGet } from './api/profile.js';
 
 export default {
-  async fetch(request, env, ctx) {
+  async fetch(request, env) {
     const url = new URL(request.url);
     const { pathname } = url;
 


### PR DESCRIPTION
## Summary
- add backend utilities within `functions` so Cloudflare deployment includes them
- update function handlers to use local utilities
- drop unused `ctx` param from worker to satisfy lint
- invoke `wrangler` via `npx` during deploy to avoid missing CLI

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba9fbac2c832db0c061462fea396d