### PR TITLE
Serve profile links without redirect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,6 +188,7 @@ export default function App(){
     return stats;
   }, [stations]);
   const photoCount = useMemo(()=> stations.reduce((acc,s)=> acc + s.visits.reduce((sum,v)=> sum + (v.photos?.length||0),0),0), [stations]);
+  const profileUrl = useMemo(() => username ? `${window.location.origin}/profile/${encodeURIComponent(username)}` : '', [username]);
 
   function handleLogin(tok, user){
     try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
@@ -479,11 +480,11 @@ export default function App(){
                     <input
                       type="text"
                       readOnly
-                      value={`${window.location.origin}/profile/${encodeURIComponent(username)}`}
+                      value={profileUrl}
                       className="flex-1 px-3 py-2 rounded-lg border-4 border-black bg-white text-xs"
                     />
                     <button
-                      onClick={()=>navigator.clipboard.writeText(`${window.location.origin}/profile/${encodeURIComponent(username)}`)}
+                      onClick={()=>navigator.clipboard.writeText(profileUrl)}
                       className="px-3 py-2 rounded-lg border-4 border-black bg-blue-500 text-white text-xs font-bold"
                     >{t('settings.account.copy')}</button>
                   </div>

--- a/src/worker.js
+++ b/src/worker.js
@@ -36,7 +36,11 @@ export default {
       return profileGet(request, env, decodeURIComponent(profileMatch[1]));
     }
     const asset = await env.ASSETS.fetch(request);
-    if (asset.status === 404 && request.method === 'GET' && !pathname.startsWith('/api/')) {
+    if (
+      request.method === 'GET' &&
+      !pathname.startsWith('/api/') &&
+      (asset.status === 404 || (asset.status >= 300 && asset.status < 400))
+    ) {
       return env.ASSETS.fetch(new Request(`${url.origin}/index.html`, request));
     }
     return asset;

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -49,4 +49,11 @@ describe('profile endpoint', () => {
     expect(body.username).toBe('bob');
     expect(body.data).toEqual(sampleData);
   });
+
+  it('returns 404 for an unknown username', async () => {
+    const res = await profileGet({ env, params: { username: 'alice' } });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('notfound');
+  });
 });

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import worker from '../src/worker.js';
+
+describe('worker routing', () => {
+  it('serves index.html for profile paths instead of redirecting', async () => {
+    const env = {
+      ASSETS: {
+        fetch: (req) => {
+          const url = new URL(req.url);
+          if (url.pathname === '/profile/Dens') {
+            return Promise.resolve(new Response(null, { status: 301, headers: { Location: '/' } }));
+          }
+          if (url.pathname === '/index.html') {
+            return Promise.resolve(new Response('index', { status: 200 }));
+          }
+          return Promise.resolve(new Response(null, { status: 404 }));
+        }
+      }
+    };
+
+    const res = await worker.fetch(new Request('https://example.com/profile/Dens'), env);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe('index');
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure worker falls back to index.html when static assets redirect or 404 so profile links render instead of redirecting home
- Add regression test verifying profile paths are served from the SPA

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9db6ea34832dac5e15d8815d8047