### PR TITLE
Fix profile route redirect

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,8 @@ import App from './App.jsx'
 import Profile from './Profile.jsx'
 import { I18nProvider } from './i18n.jsx'
 
-const match = window.location.pathname.match(/^\/profile\/(.+)$/);
+// Detect direct profile links (with optional trailing slash)
+const match = window.location.pathname.match(/^\/profile\/([^/]+)\/?$/);
 const Root = match ? <Profile username={decodeURIComponent(match[1])} /> : <App />;
 
 createRoot(document.getElementById('root')).render(

--- a/src/worker.js
+++ b/src/worker.js
@@ -32,6 +32,10 @@ export default {
 
     // ---- Statische Assets + SPA-Fallback ----
     if (request.method === 'GET' && !pathname.startsWith('/api/')) {
+      // Serve the SPA for profile links to avoid redirects
+      if (pathname.startsWith('/profile/')) {
+        return env.ASSETS.fetch(new Request(`${url.origin}/index.html`, request));
+      }
       const asset = await env.ASSETS.fetch(request);
       if (asset.status === 404) {
         // SPA-Fallback auf index.html

--- a/tests/profile-route.test.js
+++ b/tests/profile-route.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import worker from '../src/worker.js';
+
+function makeEnv(status = 301) {
+  return {
+    ASSETS: {
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === '/index.html') {
+          return new Response('INDEX', { status: 200, headers: { 'content-type': 'text/html' } });
+        }
+        return new Response(null, { status, headers: { Location: '/' } });
+      }
+    }
+  };
+}
+
+describe('profile route handling', () => {
+  it('serves index.html for direct profile links', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request('https://example.com/profile/foo'), env);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe('INDEX');
+  });
+
+  it('handles trailing slash in profile link', async () => {
+    const env = makeEnv();
+    const res = await worker.fetch(new Request('https://example.com/profile/foo/'), env);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toBe('INDEX');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `/profile/:username` links load the app instead of redirecting
- handle optional trailing slash when detecting profile page
- add tests for profile route handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb50a5bc4832da0831a5e9b6a9335