### PR TITLE
Refactor components into subdirectories and add hook-based state

### DIFF
--- a/src/components/milestones/MilestonesModal.jsx
+++ b/src/components/milestones/MilestonesModal.jsx
@@ -1,0 +1,157 @@
+import React, { useMemo } from "react";
+import { Check } from "lucide-react";
+import Modal from "../Modal";
+import { formatDate } from "../../formatDate.js";
+
+function HoverCard({ info, children }) {
+  return (
+    <div className="relative group">
+      {children}
+      <div className="pointer-events-none absolute z-20 hidden group-hover:block group-focus-within:block left-1/2 -translate-x-1/2 top-full mt-1 w-56 p-2 rounded-lg border-2 border-black bg-white text-xs shadow">
+        {info}
+      </div>
+    </div>
+  );
+}
+
+export default function MilestonesModal({
+  open,
+  onClose,
+  percent,
+  visitedCount,
+  total,
+  lineIndex,
+  typeStats,
+  stations,
+}) {
+  const firstVisitDates = useMemo(
+    () => stations.map((s) => s.visits[0]?.date).filter(Boolean).sort(),
+    [stations]
+  );
+  const dateForCount = (n) => firstVisitDates[n - 1] || null;
+  const { S = { total: 0, visited: 0 }, U = { total: 0, visited: 0 }, R = { total: 0, visited: 0 } } = typeStats || {};
+  if (!open) return null;
+  const stationMilestones = [
+    { label: "1. Besuch", count: 1, desc: "Erster besuchter Bahnhof" },
+    { label: "Hattrick", count: 3, desc: "3 besuchte Bahnhöfe" },
+    { label: "10%", percent: 10 },
+    { label: "25%", percent: 25 },
+    { label: "50%", percent: 50 },
+    { label: "75%", percent: 75 },
+    { label: "Fast geschafft!", count: Math.max(total - 3, 0), desc: "Nur noch 3 Bahnhöfe bis 100%" },
+    { label: "100%", percent: 100 },
+  ].map((m) => {
+    const count = m.count ?? Math.ceil(total * (m.percent / 100));
+    const done = visitedCount >= count;
+    const date = done ? dateForCount(count) : null;
+    const base = m.percent
+      ? `${m.label} - das entspricht ${Math.round(total * (m.percent / 100))} besuchten Bahnhöfen`
+      : m.desc;
+    const info = done ? `${base}. Erreicht am: ${formatDate(date)}` : `${base}. Noch nicht erreicht.`;
+    return { ...m, count, done, info };
+  });
+  return (
+    <Modal open={open} onClose={onClose} title="Meilensteine">
+      <div className="space-y-6">
+        <section>
+          <div className="font-extrabold mb-2">Gesamt-Fortschritt</div>
+          <div className="w-full h-4 rounded-full border-4 border-black bg-white overflow-hidden">
+            {percent > 0 && <div className="h-full bg-green-500" style={{ width: `${percent}%` }} />}
+          </div>
+          <div className="text-sm mt-1">{visitedCount}/{total} ({percent}%)</div>
+        </section>
+        <section>
+          <div className="font-extrabold mb-2">Stationen-Ziele</div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {stationMilestones.map((m) => (
+              <HoverCard key={m.label} info={m.info}>
+                <button
+                  type="button"
+                  className={`w-full rounded-xl border-4 border-black p-2 text-center ${m.done ? "bg-green-300" : "bg-white"}`}
+                >
+                  <div className="font-black">{m.label}</div>
+                  <div className="text-xs flex items-center justify-center gap-1">
+                    {m.done ? <Check size={14} /> : null} {m.done ? "erreicht" : "offen"}
+                  </div>
+                </button>
+              </HoverCard>
+            ))}
+          </div>
+        </section>
+        <section>
+          <div className="font-extrabold mb-2">Netz-Ziele</div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {[
+              { label: "100% S-Bahnhöfe", stat: S, type: "S" },
+              { label: "100% U-Bahnhöfe", stat: U, type: "U" },
+              { label: "100% Regionalbahnhöfe", stat: R, type: "R" },
+            ].map(({ label, stat, type }) => {
+              const done = stat.visited >= stat.total && stat.total > 0;
+              const pct = stat.total ? Math.round((stat.visited / stat.total) * 100) : 0;
+              const dates = stations
+                .filter((s) => s.types.includes(type) && s.visits[0]?.date)
+                .map((s) => s.visits[0].date)
+                .sort();
+              const date = done ? dates[stat.total - 1] : null;
+              const info = done
+                ? `${label} - erreicht am: ${formatDate(date)}`
+                : `${stat.visited}/${stat.total} Bahnhöfe (${pct}%)`;
+              return (
+                <HoverCard key={label} info={info}>
+                  <button
+                    type="button"
+                    className={`w-full rounded-xl border-4 border-black p-2 text-center ${done ? "bg-green-300" : "bg-white"}`}
+                  >
+                    <div className="font-black">{label}</div>
+                    <div className="text-xs flex items-center justify-center gap-1">
+                      {done ? <Check size={14} /> : null} {done ? "erreicht" : `${stat.visited}/${stat.total} (${pct}%)`}
+                    </div>
+                  </button>
+                </HoverCard>
+              );
+            })}
+          </div>
+        </section>
+        <section>
+          <div className="font-extrabold mb-2">Linien</div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {Object.entries(lineIndex).map(([line, stat]) => {
+              const done = stat.visited >= stat.total && stat.total > 0;
+              const pct = Math.round((stat.visited / stat.total) * 100);
+              const visitedStations = stations.filter(
+                (s) => (s.lines || []).includes(line) && s.visits.length > 0
+              );
+              const visitedNames = visitedStations.map((s) => s.name);
+              const dates = visitedStations
+                .map((s) => s.visits[0]?.date)
+                .filter(Boolean)
+                .sort();
+              const date = done ? dates[stat.total - 1] : null;
+              const info = visitedNames.length
+                ? done
+                  ? `Alle Bahnhöfe besucht${date ? ` am ${formatDate(date)}` : ""}`
+                  : `Besuchte Bahnhöfe: ${visitedNames.join(", ")}`
+                : "Noch keine Bahnhöfe besucht";
+              return (
+                <HoverCard key={line} info={info}>
+                  <button
+                    type="button"
+                    className={`w-full rounded-xl border-4 border-black p-2 ${done ? "bg-green-200" : "bg-white"}`}
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="px-2 py-0.5 text-xs font-black rounded-full border-2 border-black bg-white">{line}</span>
+                      <div className="text-xs ml-auto">{stat.visited}/{stat.total} ({pct}%)</div>
+                    </div>
+                    <div className="w-full h-3 rounded-full border-2 border-black bg-white overflow-hidden">
+                      {pct > 0 && <div className="h-full bg-green-500" style={{ width: `${pct}%` }} />}
+                    </div>
+                  </button>
+                </HoverCard>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/navigation/HeaderLogo.jsx
+++ b/src/components/navigation/HeaderLogo.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import logo from "../assets/header-logo.svg";
-import { useI18n } from "../i18n.jsx";
+import logo from "../../assets/header-logo.svg";
+import { useI18n } from "../../i18n.jsx";
 
 export default function HeaderLogo({ className = "" }) {
   const { t } = useI18n();

--- a/src/components/settings/AddVisitForm.jsx
+++ b/src/components/settings/AddVisitForm.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import { Camera } from "lucide-react";
+import { useI18n } from "../../i18n.jsx";
+import { fileToDataUrl } from "../../imageUtils.js";
+
+export default function AddVisitForm({ stationId, onSave }) {
+  const { t } = useI18n();
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [note, setNote] = useState("");
+  const [photos, setPhotos] = useState([]);
+
+  async function onFile(e) {
+    const files = Array.from(e.target.files || []);
+    if (!files.length) return;
+    const urls = await Promise.all(files.map(fileToDataUrl));
+    setPhotos((p) => [...p, ...urls]);
+  }
+
+  function submit() {
+    if (!date) return alert(t("addVisitForm.dateRequired"));
+    onSave(stationId, {
+      date,
+      note: note.trim() || undefined,
+      photos: photos.length ? photos : undefined,
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="font-bold text-sm">{t("addVisitForm.date")}</label>
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="w-full mt-1 px-3 py-2 rounded-lg border-4 border-black bg-white"
+        />
+      </div>
+      <div>
+        <label className="font-bold text-sm">{t("addVisitForm.note")}</label>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          className="w-full mt-1 px-3 py-2 rounded-lg border-2 border-black bg-white"
+          placeholder="z.B. Sonnenuntergang auf der Brücke 🌇"
+        />
+      </div>
+      <div>
+        <label className="font-bold text-sm block mb-1">{t("addVisitForm.photos")}</label>
+        <label className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-amber-300 border-4 border-black cursor-pointer font-extrabold">
+          <Camera size={18} /> {t("addVisitForm.chooseFile")}
+          <input type="file" accept="image/*" multiple className="hidden" onChange={onFile} />
+        </label>
+        {photos.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {photos.map((p, i) => (
+              <img key={i} src={p} alt="Preview" className="max-h-56 rounded-xl border-4 border-black" />
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="flex">
+        <button
+          onClick={submit}
+          className="w-full md:w-auto px-6 py-2 rounded-full bg-black text-white font-extrabold border-4 border-black"
+        >
+          {t("addVisitForm.save")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ChangePasswordForm.jsx
+++ b/src/components/settings/ChangePasswordForm.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+
+export default function ChangePasswordForm({ onSave, onCancel }) {
+  const [oldPw, setOldPw] = useState("");
+  const [newPw, setNewPw] = useState("");
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="font-bold text-sm">Altes Passwort</label>
+        <input
+          type="password"
+          value={oldPw}
+          onChange={(e) => setOldPw(e.target.value)}
+          className="w-full mt-1 px-3 py-2 rounded-lg border-4 border-black bg-white"
+        />
+      </div>
+      <div>
+        <label className="font-bold text-sm">Neues Passwort</label>
+        <input
+          type="password"
+          value={newPw}
+          onChange={(e) => setNewPw(e.target.value)}
+          className="w-full mt-1 px-3 py-2 rounded-lg border-4 border-black bg-white"
+        />
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button onClick={onCancel} className="px-4 py-2 rounded-lg bg-white">
+          Abbrechen
+        </button>
+        <button
+          onClick={() => onSave(oldPw, newPw)}
+          className="px-4 py-2 rounded-lg bg-black text-white"
+        >
+          Speichern
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -1,0 +1,9 @@
+export function formatDate(iso) {
+  if (!iso) return "";
+  try {
+    const d = new Date(iso + (iso.length === 10 ? "T00:00:00" : ""));
+    return d.toLocaleDateString("de-DE", { year: "numeric", month: "2-digit", day: "2-digit" });
+  } catch {
+    return iso;
+  }
+}

--- a/src/hooks/useScrollTop.js
+++ b/src/hooks/useScrollTop.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export default function useScrollTop() {
+  const [showScrollTop, setShowScrollTop] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setShowScrollTop(window.scrollY > window.innerHeight * 1.5);
+    };
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
+
+  return { showScrollTop, scrollToTop };
+}

--- a/tests/change-password-form.test.jsx
+++ b/tests/change-password-form.test.jsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import ChangePasswordForm from "../src/components/settings/ChangePasswordForm.jsx";
+
+describe("ChangePasswordForm", () => {
+  it("renders password fields", () => {
+    const html = renderToString(<ChangePasswordForm onSave={() => {}} onCancel={() => {}} />);
+    expect(html).toContain("Altes Passwort");
+    expect(html).toContain("Neues Passwort");
+  });
+});

--- a/tests/milestones-modal.test.jsx
+++ b/tests/milestones-modal.test.jsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import MilestonesModal from "../src/components/milestones/MilestonesModal.jsx";
+
+describe("MilestonesModal", () => {
+  it("renders milestone sections", () => {
+    const html = renderToString(
+      <MilestonesModal
+        open={true}
+        onClose={() => {}}
+        percent={0}
+        visitedCount={0}
+        total={10}
+        lineIndex={{}}
+        typeStats={{}}
+        stations={[]}
+      />
+    );
+    expect(html).toContain("Gesamt-Fortschritt");
+    expect(html).toContain("Stationen-Ziele");
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, googleMapsUrl, pickThreeUnvisited, rollAllowed, makeDataUrl, stationLabel } from '../src/App.jsx';
+import { googleMapsUrl, pickThreeUnvisited, rollAllowed, makeDataUrl, stationLabel } from '../src/App.jsx';
+import { formatDate } from '../src/formatDate.js';
 
 describe('utility functions', () => {
   it('formats ISO dates in de-DE format', () => {


### PR DESCRIPTION
## Summary
- organize components into navigation, settings and milestones folders
- extract milestone, visit, and password components from `App.jsx`
- add `useScrollTop` hook for scroll-to-top state
- cover new components with simple unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc0b475d4832d9b81485ac8dcef96