### PR TITLE
Refactor storage to per-user KV records

### DIFF
--- a/functions/api/account.ts
+++ b/functions/api/account.ts
@@ -1,16 +1,15 @@
-import { getDb, saveDb, auth } from '../_utils';
+import { auth, getUser, deleteUser, deleteStations, deleteSessionsForUser } from '../_utils';
 
 export const onRequestDelete = async ({ request, env }: { request: Request; env: any }): Promise<Response> => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  db.users = db.users.filter(u => u.id !== user.id);
-  delete db.data[user.id];
-  for (const [t, uid] of Object.entries(db.sessions)) {
-    if (uid === user.id) delete db.sessions[t];
+  const existing = await getUser(env, user.id);
+  if (existing) {
+    await deleteUser(env, existing);
+    await deleteStations(env, user.id);
+    await deleteSessionsForUser(env, user.id);
   }
-  await saveDb(env, db);
   return Response.json({ success: true });
 };

--- a/functions/api/data.ts
+++ b/functions/api/data.ts
@@ -1,22 +1,20 @@
-import { getDb, saveDb, parseBody, auth } from '../_utils';
+import { parseBody, auth, getStations, saveStations } from '../_utils';
 
 export const onRequestGet = async ({ request, env }: { request: Request; env: any }): Promise<Response> => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  return Response.json({ data: db.data[user.id] || null });
+  const data = await getStations(env, user.id);
+  return Response.json({ data: data || null });
 };
 
 export const onRequestPost = async ({ request, env }: { request: Request; env: any }): Promise<Response> => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
   const { data } = await parseBody(request);
-  db.data[user.id] = data;
-  await saveDb(env, db);
+  await saveStations(env, user.id, data);
   return Response.json({ success: true });
 };

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -1,14 +1,12 @@
-import { getDb, saveDb, parseBody, verifyPassword, randomHex } from '../_utils';
+import { parseBody, verifyPassword, randomHex, getUserByUsername, saveSession } from '../_utils';
 
 export const onRequestPost = async ({ request, env }: { request: Request; env: any }): Promise<Response> => {
   const { username, password } = await parseBody(request);
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === username);
+  const user = await getUserByUsername(env, username);
   if (!user || !(await verifyPassword(password, user.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 401 });
   }
   const token = randomHex(24);
-  db.sessions[token] = user.id;
-  await saveDb(env, db);
+  await saveSession(env, token, user.id);
   return Response.json({ token });
 };

--- a/functions/api/logout.ts
+++ b/functions/api/logout.ts
@@ -1,12 +1,10 @@
-import { getDb, saveDb } from '../_utils';
+import { deleteSession } from '../_utils';
 
 export const onRequestPost = async ({ request, env }: { request: Request; env: any }): Promise<Response> => {
-  const db = await getDb(env);
   const authHeader = request.headers.get('authorization');
   if (authHeader) {
     const token = authHeader.split(' ')[1];
-    delete db.sessions[token];
-    await saveDb(env, db);
+    await deleteSession(env, token);
   }
   return Response.json({ success: true });
 };

--- a/functions/api/profile/[username].ts
+++ b/functions/api/profile/[username].ts
@@ -1,10 +1,10 @@
-import { getDb } from '../../_utils';
+import { getUserByUsername, getStations } from '../../_utils';
 
 export const onRequestGet = async ({ env, params }: { env: any; params: { username: string } }): Promise<Response> => {
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === params.username);
+  const user = await getUserByUsername(env, params.username);
   if (!user) {
     return new Response(JSON.stringify({ error: 'notfound' }), { status: 404 });
   }
-  return Response.json({ username: user.username, data: db.data[user.id] || null });
+  const data = await getStations(env, user.id);
+  return Response.json({ username: user.username, data: data || null });
 };

--- a/functions/api/register.ts
+++ b/functions/api/register.ts
@@ -1,16 +1,15 @@
-import { getDb, saveDb, parseBody, hashPassword } from '../_utils';
+import { parseBody, hashPassword, getUserByUsername, saveUser, randomHex } from '../_utils';
 
 export const onRequestPost = async ({ request, env }: { request: Request; env: any }): Promise<Response> => {
   const { username, password } = await parseBody(request);
   if (!username || !password) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const db = await getDb(env);
-  if (db.users.find(u => u.username === username)) {
+  const existing = await getUserByUsername(env, username);
+  if (existing) {
     return new Response(JSON.stringify({ error: 'exists' }), { status: 400 });
   }
-  const id = db.users.length ? Math.max(...db.users.map(u => u.id)) + 1 : 1;
-  db.users.push({ id, username, password: await hashPassword(password) });
-  await saveDb(env, db);
+  const id = randomHex(8);
+  await saveUser(env, { id, username, password: await hashPassword(password) });
   return Response.json({ success: true });
 };

--- a/scripts/migrateDb.js
+++ b/scripts/migrateDb.js
@@ -1,0 +1,22 @@
+export default {
+  async fetch(request, env) {
+    const legacy = await env.DB.get('db');
+    if (!legacy) {
+      return new Response('no legacy db', { status: 404 });
+    }
+    const { users = [], data = {}, sessions = {} } = JSON.parse(legacy);
+    for (const user of users) {
+      await env.DB.put(`user:${user.id}`, JSON.stringify(user));
+      await env.DB.put(`username:${user.username}`, String(user.id));
+      if (data[user.id] !== undefined) {
+        await env.DB.put(`data:${user.id}`, JSON.stringify(data[user.id]));
+      }
+    }
+    for (const [token, uid] of Object.entries(sessions)) {
+      await env.DB.put(`session:${token}`, String(uid));
+    }
+    await env.DB.delete('db');
+    return new Response('migration complete');
+  }
+};
+

--- a/src/api/data.js
+++ b/src/api/data.js
@@ -1,22 +1,20 @@
-import { getDb, saveDb, parseBody, auth } from '../utils.js';
+import { parseBody, auth, getStations, saveStations } from '../utils.js';
 
 export async function dataGet(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  return Response.json({ data: db.data[user.id] || null });
+  const data = await getStations(env, user.id);
+  return Response.json({ data: data || null });
 }
 
 export async function dataPost(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
   const { data } = await parseBody(request);
-  db.data[user.id] = data;
-  await saveDb(env, db);
+  await saveStations(env, user.id, data);
   return Response.json({ success: true });
 }

--- a/src/api/login.js
+++ b/src/api/login.js
@@ -1,14 +1,12 @@
-import { getDb, saveDb, parseBody, verifyPassword, randomHex } from '../utils.js';
+import { parseBody, verifyPassword, randomHex, getUserByUsername, saveSession } from '../utils.js';
 
 export async function login(request, env) {
   const { username, password } = await parseBody(request);
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === username);
+  const user = await getUserByUsername(env, username);
   if (!user || !(await verifyPassword(password, user.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 401 });
   }
   const token = randomHex(24);
-  db.sessions[token] = user.id;
-  await saveDb(env, db);
+  await saveSession(env, token, user.id);
   return Response.json({ token });
 }

--- a/src/api/logout.js
+++ b/src/api/logout.js
@@ -1,12 +1,10 @@
-import { getDb, saveDb } from '../utils.js';
+import { deleteSession } from '../utils.js';
 
 export async function logout(request, env) {
-  const db = await getDb(env);
   const authHeader = request.headers.get('authorization');
   if (authHeader) {
     const token = authHeader.split(' ')[1];
-    delete db.sessions[token];
-    await saveDb(env, db);
+    await deleteSession(env, token);
   }
   return Response.json({ success: true });
 }

--- a/src/api/password.js
+++ b/src/api/password.js
@@ -1,8 +1,7 @@
-import { getDb, saveDb, parseBody, auth, hashPassword, verifyPassword } from '../utils.js';
+import { parseBody, auth, hashPassword, verifyPassword, getUser, saveUser } from '../utils.js';
 
 export async function password(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
@@ -10,11 +9,11 @@ export async function password(request, env) {
   if (!oldPassword || !newPassword) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const u = db.users.find(u => u.id === user.id);
+  const u = await getUser(env, user.id);
   if (!u || !(await verifyPassword(oldPassword, u.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 400 });
   }
   u.password = await hashPassword(newPassword);
-  await saveDb(env, db);
+  await saveUser(env, u);
   return Response.json({ success: true });
 }

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -1,10 +1,10 @@
-import { getDb } from '../utils.js';
+import { getUserByUsername, getStations } from '../utils.js';
 
 export async function profileGet(request, env, username) {
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === username);
+  const user = await getUserByUsername(env, username);
   if (!user) {
     return new Response(JSON.stringify({ error: 'notfound' }), { status: 404 });
   }
-  return Response.json({ username: user.username, data: db.data[user.id] || null });
+  const data = await getStations(env, user.id);
+  return Response.json({ username: user.username, data: data || null });
 }

--- a/src/api/register.js
+++ b/src/api/register.js
@@ -1,16 +1,15 @@
-import { getDb, saveDb, parseBody, hashPassword } from '../utils.js';
+import { parseBody, hashPassword, getUserByUsername, saveUser, randomHex } from '../utils.js';
 
 export async function register(request, env) {
   const { username, password } = await parseBody(request);
   if (!username || !password) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const db = await getDb(env);
-  if (db.users.find(u => u.username === username)) {
+  const existing = await getUserByUsername(env, username);
+  if (existing) {
     return new Response(JSON.stringify({ error: 'exists' }), { status: 400 });
   }
-  const id = db.users.length ? Math.max(...db.users.map(u => u.id)) + 1 : 1;
-  db.users.push({ id, username, password: await hashPassword(password) });
-  await saveDb(env, db);
+  const id = randomHex(8);
+  await saveUser(env, { id, username, password: await hashPassword(password) });
   return Response.json({ success: true });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,51 @@
-export async function getDb(env){
-  const data = await env.DB.get('db');
-  return data ? JSON.parse(data) : { users: [], data: {}, sessions: {} };
+
+export async function getUser(env, id){
+  const data = await env.DB.get(`user:${id}`);
+  return data ? JSON.parse(data) : null;
 }
 
-export async function saveDb(env, db){
-  await env.DB.put('db', JSON.stringify(db));
+export async function getUserByUsername(env, username){
+  const id = await env.DB.get(`username:${username}`);
+  return id ? await getUser(env, id) : null;
+}
+
+export async function saveUser(env, user){
+  await env.DB.put(`user:${user.id}`, JSON.stringify(user));
+  await env.DB.put(`username:${user.username}`, user.id);
+}
+
+export async function deleteUser(env, user){
+  await env.DB.delete(`user:${user.id}`);
+  await env.DB.delete(`username:${user.username}`);
+}
+
+export async function getStations(env, userId){
+  const data = await env.DB.get(`data:${userId}`);
+  return data ? JSON.parse(data) : null;
+}
+
+export async function saveStations(env, userId, stations){
+  await env.DB.put(`data:${userId}`, JSON.stringify(stations));
+}
+
+export async function deleteStations(env, userId){
+  await env.DB.delete(`data:${userId}`);
+}
+
+export async function saveSession(env, token, userId){
+  await env.DB.put(`session:${token}`, String(userId));
+}
+
+export async function deleteSession(env, token){
+  await env.DB.delete(`session:${token}`);
+}
+
+export async function deleteSessionsForUser(env, userId){
+  const list = await env.DB.list({ prefix: 'session:' });
+  await Promise.all(list.keys.map(async k => {
+    const uid = await env.DB.get(k.name);
+    if (uid === String(userId)) await env.DB.delete(k.name);
+  }));
 }
 
 export async function parseBody(request){
@@ -32,11 +73,11 @@ export async function verifyPassword(password, stored){
   return hashHex === computed;
 }
 
-export function auth(request, db){
+export async function auth(request, env){
   const authHeader = request.headers.get('authorization');
   if (!authHeader) return null;
   const token = authHeader.split(' ')[1];
-  const uid = db.sessions[token];
+  const uid = await env.DB.get(`session:${token}`);
   return uid ? { id: uid } : null;
 }
 


### PR DESCRIPTION
## Summary
- replace monolithic `db` access with per-user/session/station KV helpers
- update API routes to new storage layer
- add migration worker to split legacy `db` key

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc5a1d348832db52877eadaaffafc