### PR TITLE
Add standalone profile page

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zufallstour 3000 Berlin</title>
+   <script>
+      const isLocal = ['localhost', '127.0.0.1'].includes(location.hostname)
+        || /^10\./.test(location.hostname)
+        || /^192\.168\./.test(location.hostname)
+        || /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(location.hostname)
+
+      if (location.protocol !== 'https:' && !isLocal) {
+        location.replace('https:' + location.href.substring(location.protocol.length))
+      }
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/profile.jsx"></script>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil, ImageUp, KeyRound, LogOut, ArrowUp, HelpCircle, Plus, X } from "lucide-react";
+import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil, ImageUp, KeyRound, LogOut, ArrowUp, HelpCircle, Plus, X, Eye } from "lucide-react";
 import { fetchJourneyDuration } from "./journeys";
 import { seedStations } from "./seed_stations";
 import HeaderLogo from "./components/navigation/HeaderLogo";
@@ -185,7 +185,7 @@ export default function App(){
     return stats;
   }, [stations]);
   const photoCount = useMemo(()=> stations.reduce((acc,s)=> acc + s.visits.reduce((sum,v)=> sum + (v.photos?.length||0),0),0), [stations]);
-  const profileUrl = useMemo(() => username ? `${window.location.origin}/profile/${encodeURIComponent(username)}` : '', [username]);
+  const profileUrl = useMemo(() => username ? `${window.location.origin}/profil/${encodeURIComponent(username)}` : '', [username]);
 
   function handleLogin(tok, user){
     try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
@@ -484,6 +484,16 @@ export default function App(){
                       onClick={()=>navigator.clipboard.writeText(profileUrl)}
                       className="px-3 py-2 rounded-lg border-4 border-black bg-blue-500 text-white text-xs font-bold"
                     >{t('settings.account.copy')}</button>
+                    <a
+                      href={profileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="p-2 rounded-lg border-4 border-black bg-white text-black flex items-center justify-center"
+                      aria-label={t('settings.account.open')}
+                      title={t('settings.account.open')}
+                    >
+                      <Eye size={16} />
+                    </a>
                   </div>
                 </div>
               </>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -25,6 +25,7 @@
   "settings.account.loggedInAs": "Angemeldet als",
   "settings.account.profileLink": "Profil-Link",
   "settings.account.copy": "Kopieren",
+  "settings.account.open": "Ansehen",
   "settings.language": "Sprache",
   "settings.language.de": "Deutsch",
   "settings.language.en": "Englisch",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,7 @@
   "settings.account.loggedInAs": "Logged in as",
   "settings.account.profileLink": "Profile link",
   "settings.account.copy": "Copy",
+  "settings.account.open": "Open",
   "settings.language": "Language",
   "settings.language.de": "German",
   "settings.language.en": "English",

--- a/src/profile.jsx
+++ b/src/profile.jsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import Profile from './Profile.jsx'
 import { I18nProvider } from './i18n.jsx'
+
+const match = window.location.pathname.match(/^\/profil\/([^/]+)\/?$/)
+const username = match ? decodeURIComponent(match[1]) : ''
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <I18nProvider>
-      <App />
+      <Profile username={username} />
     </I18nProvider>
   </StrictMode>,
 )

--- a/src/worker.js
+++ b/src/worker.js
@@ -32,9 +32,12 @@ export default {
 
     // ---- Statische Assets + SPA-Fallback ----
     if (request.method === 'GET' && !pathname.startsWith('/api/')) {
-      // Serve the SPA for profile links to avoid redirects
+      // Serve the dedicated profile SPA for direct links
+      if (pathname.startsWith('/profil/')) {
+        return env.ASSETS.fetch(new Request(`${url.origin}/profile.html`, request));
+      }
       if (pathname.startsWith('/profile/')) {
-        return env.ASSETS.fetch(new Request(`${url.origin}/index.html`, request));
+        return env.ASSETS.fetch(new Request(`${url.origin}/profile.html`, request));
       }
       const asset = await env.ASSETS.fetch(request);
       if (asset.status === 404) {

--- a/tests/profile-route.test.js
+++ b/tests/profile-route.test.js
@@ -6,8 +6,8 @@ function makeEnv(status = 301) {
     ASSETS: {
       async fetch(request) {
         const url = new URL(request.url);
-        if (url.pathname === '/index.html') {
-          return new Response('INDEX', { status: 200, headers: { 'content-type': 'text/html' } });
+        if (url.pathname === '/profile.html') {
+          return new Response('PROFILE', { status: 200, headers: { 'content-type': 'text/html' } });
         }
         return new Response(null, { status, headers: { Location: '/' } });
       }
@@ -16,19 +16,19 @@ function makeEnv(status = 301) {
 }
 
 describe('profile route handling', () => {
-  it('serves index.html for direct profile links', async () => {
+  it('serves profile.html for direct profile links', async () => {
     const env = makeEnv();
-    const res = await worker.fetch(new Request('https://example.com/profile/foo'), env);
+    const res = await worker.fetch(new Request('https://example.com/profil/foo'), env);
     expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toBe('INDEX');
+    expect(text).toBe('PROFILE');
   });
 
   it('handles trailing slash in profile link', async () => {
     const env = makeEnv();
-    const res = await worker.fetch(new Request('https://example.com/profile/foo/'), env);
+    const res = await worker.fetch(new Request('https://example.com/profil/foo/'), env);
     expect(res.status).toBe(200);
     const text = await res.text();
-    expect(text).toBe('INDEX');
+    expect(text).toBe('PROFILE');
   });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,5 +20,13 @@ export default defineConfig({
         secure: false,
       }
     }
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        profile: 'profile.html'
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- create dedicated `profile.html` and `src/profile.jsx` entry for profile pages
- update app and worker to use `/profil/{username}` links
- include profile entry in Vite build configuration
- add button in settings to copy or open profile link with an eye icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6aa85220832d87190035bf2522a5