### PR TITLE
Fix profile text placeholders and share global styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/index.css" />
     <title>Zufallstour 3000 Berlin</title>
    <script>
       const isLocal = ['localhost', '127.0.0.1'].includes(location.hostname)

--- a/profile.html
+++ b/profile.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/index.css" />
     <title>Zufallstour 3000 Berlin</title>
    <script>
       const isLocal = ['localhost', '127.0.0.1'].includes(location.hostname)

--- a/src/i18n.jsx
+++ b/src/i18n.jsx
@@ -12,7 +12,13 @@ export function I18nProvider({ children }) {
     document.documentElement.lang = lang;
     document.title = translations[lang]['app.title'] || 'Zufallstour 3000';
   }, [lang]);
-  const t = (key) => translations[lang][key] || key;
+  const t = (key, vars = {}) => {
+    let str = translations[lang][key] || key;
+    Object.entries(vars).forEach(([vk, vv]) => {
+      str = str.replace(new RegExp(`{{${vk}}}`, 'g'), String(vv));
+    });
+    return str;
+  };
   return (
     <I18nContext.Provider value={{ lang, setLang, t }}>
       {children}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import App from './App.jsx'
 import { I18nProvider } from './i18n.jsx'
 

--- a/src/profile.jsx
+++ b/src/profile.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import Profile from './Profile.jsx'
 import { I18nProvider } from './i18n.jsx'
 


### PR DESCRIPTION
## Summary
- interpolate i18n placeholders so profile names and line numbers render
- load shared Tailwind CSS from HTML entries
- remove CSS imports from entry points to rely on common stylesheet

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e74867974832d9803d8dd0c8fbe94