### PR TITLE
Add imprint and privacy policy pages with footer links

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/index.css" />
+    <title>Datenschutzerklärung - Zufallstour 3000 Berlin</title>
+  </head>
+  <body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Datenschutzerklärung</h1>
+    <p>Wir nehmen den Schutz Ihrer persönlichen Daten sehr ernst. Personenbezogene Daten werden vertraulich und gemäß den gesetzlichen Datenschutzvorschriften behandelt.</p>
+
+    <h2 class="text-xl font-bold mt-4 mb-2">Verantwortlicher</h2>
+    <p>
+      Zufallstour 3000 Berlin<br />
+      Max Mustermann<br />
+      Musterstraße 1<br />
+      12345 Berlin<br />
+      E-Mail: <a href="mailto:kontakt@zufallstour3000.example" class="underline">kontakt@zufallstour3000.example</a>
+    </p>
+
+    <h2 class="text-xl font-bold mt-4 mb-2">Erhebung und Speicherung personenbezogener Daten</h2>
+    <p>Beim Aufrufen unserer Website werden automatisch Informationen in so genannten Server-Log-Dateien gespeichert, die Ihr Browser automatisch übermittelt. Dies sind:</p>
+    <ul class="list-disc list-inside">
+      <li>Browsertyp und Browserversion</li>
+      <li>verwendetes Betriebssystem</li>
+      <li>Referrer URL</li>
+      <li>Hostname des zugreifenden Rechners</li>
+      <li>Uhrzeit der Serveranfrage</li>
+    </ul>
+    <p>Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht vorgenommen.</p>
+
+    <h2 class="text-xl font-bold mt-4 mb-2">Cookies und lokale Speicherung</h2>
+    <p>Unsere Website verwendet keine Cookies. Lokale Speichertechnologien Ihres Browsers werden ausschließlich zur Speicherung Ihrer individuellen Einstellungen und Einträge verwendet.</p>
+
+    <h2 class="text-xl font-bold mt-4 mb-2">Kontakt</h2>
+    <p>Wenn Sie uns per E-Mail Anfragen zukommen lassen, werden Ihre Angaben aus der E-Mail inklusive der von Ihnen dort angegebenen Kontaktdaten zwecks Bearbeitung der Anfrage und für den Fall von Anschlussfragen bei uns gespeichert.</p>
+
+    <h2 class="text-xl font-bold mt-4 mb-2">Ihre Rechte</h2>
+    <p>Sie haben jederzeit das Recht auf unentgeltliche Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der Datenverarbeitung sowie ein Recht auf Berichtigung, Sperrung oder Löschung dieser Daten.</p>
+  </body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/index.css" />
+    <title>Impressum - Zufallstour 3000 Berlin</title>
+  </head>
+  <body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Impressum</h1>
+    <p>Angaben gemäß § 5 TMG</p>
+    <p>
+      Zufallstour 3000 Berlin<br />
+      Max Mustermann<br />
+      Musterstraße 1<br />
+      12345 Berlin
+    </p>
+    <p>
+      Kontakt:<br />
+      E-Mail: <a href="mailto:kontakt@zufallstour3000.example" class="underline">kontakt@zufallstour3000.example</a>
+    </p>
+    <p>
+      Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV:<br />
+      Max Mustermann<br />
+      Adresse wie oben
+    </p>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import { fileToDataUrl } from "./imageUtils.js";
 import helpDe from "./help.de.html?raw";
 import helpEn from "./help.en.html?raw";
 import { formatDate } from "./formatDate.js";
+import Footer from "./components/Footer.jsx";
 
 // Helpers & Types
 const STORAGE_KEY = "zufallstour3000.v4";
@@ -345,11 +346,12 @@ export default function App(){
   }
   
 
-  return (
-    <div className="min-h-screen w-full bg-[repeating-linear-gradient(135deg,_#ffea61_0,_#ffea61_8px,_#ffd447_8px,_#ffd447_16px)] p-3 sm:p-6">
-      <div className="max-w-3xl mx-auto">
-        <HeaderLogo className="h-16 w-auto mx-auto my-0" />
-        <style>{`
+    return (
+      <>
+        <div className="min-h-screen w-full bg-[repeating-linear-gradient(135deg,_#ffea61_0,_#ffea61_8px,_#ffd447_8px,_#ffd447_16px)] p-3 sm:p-6">
+          <div className="max-w-3xl mx-auto">
+            <HeaderLogo className="h-16 w-auto mx-auto my-0" />
+            <style>{`
           button{cursor:pointer}
           @keyframes shake{10%,90%{transform:translateX(-1px)}20%,80%{transform:translateX(2px)}30%,50%,70%{transform:translateX(-4px)}40%,60%{transform:translateX(4px)}}
           @keyframes slamIn{0%{transform:scale(.2) rotate(-35deg);opacity:0}60%{transform:scale(1.15) rotate(8deg);opacity:1}80%{transform:scale(1.03) rotate(-6deg)}100%{transform:scale(1) rotate(-8deg)}}
@@ -553,11 +555,13 @@ export default function App(){
           </button>
         )}
 
-        <div className="mt-10 text-center text-xs opacity-70"><p>{t('footer.madeWith')}</p></div>
-      </div>
-    </div>
-  );
-}
+            <div className="mt-10 text-center text-xs opacity-70"><p>{t('footer.madeWith')}</p></div>
+          </div>
+        </div>
+        <Footer />
+      </>
+    );
+  }
 
 // Station Row
 function StationRow({ st, origin, onAddVisit, onUnvisit }){

--- a/src/Profile.jsx
+++ b/src/Profile.jsx
@@ -3,6 +3,7 @@ import { stationLabel } from './App.jsx';
 import { useI18n } from './i18n.jsx';
 import LineChips from './components/LineChips.jsx';
 import { Check } from 'lucide-react';
+import Footer from './components/Footer.jsx';
 
 function formatDate(iso){
   if(!iso) return '';
@@ -96,6 +97,7 @@ export default function Profile({ username }) {
   if(!stations) return <div className="p-4">{t('profile.loading')}</div>;
 
   return (
+    <>
     <div className="p-4">
       <div className="rounded-[28px] border-4 border-black shadow-[10px_10px_0_0_rgba(0,0,0,0.6)] bg-gradient-to-br from-teal-300 via-rose-200 to-amber-200 p-4 sm:p-6 space-y-6">
         <h1 className="text-2xl font-extrabold">{t('profile.title',{username})}</h1>
@@ -142,5 +144,7 @@ export default function Profile({ username }) {
         </section>
       </div>
     </div>
+    <Footer />
+    </>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function Footer(){
+  return (
+    <footer className="text-center text-xs p-4">
+      <a href="/impressum.html" className="underline">Impressum</a>
+      {" "}·{" "}
+      <a href="/datenschutz.html" className="underline">Datenschutz</a>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable footer linking to imprint and privacy policy
- create static pages for Impressum and Datenschutzerklärung
- include footer on main and profile pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6c4293ac832d8175a8ffa197eb93