### PR TITLE
Fix profile page username parsing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, Check, ChevronLeft, Trophy, Pencil, ImageUp, KeyRound, LogOut, ArrowUp, HelpCircle, Plus, X, Eye } from "lucide-react";
+import { Settings as SettingsIcon, Shuffle, MapPin, Camera, Upload, Download, Trash2, ArrowUpDown, ChevronLeft, Trophy, Pencil, ImageUp, KeyRound, LogOut, ArrowUp, HelpCircle, Plus, X, Eye } from "lucide-react";
 import { fetchJourneyDuration } from "./journeys";
 import { seedStations } from "./seed_stations";
 import HeaderLogo from "./components/navigation/HeaderLogo";
 import LineChips from "./components/LineChips";
 import Modal from "./components/Modal";
-import ComboBox from "./components/ComboBox";
 import ManualVisitForm from "./components/ManualVisitForm";
 import ZoomBox from "./components/ZoomBox";
 import ChangePasswordForm from "./components/settings/ChangePasswordForm";
@@ -88,10 +87,10 @@ const normalizeStations = (data) => {
     ...st,
     visits: Array.isArray(st.visits)
       ? st.visits.map(v => {
+          const { photo, ...rest } = v || {};
           const photos = Array.isArray(v.photos)
             ? v.photos
-            : (v.photo ? [v.photo] : []);
-          const { photo: _photo, ...rest } = v || {};
+            : (photo ? [photo] : []);
           return { ...rest, photos };
         })
       : [],

--- a/src/components/settings/ChangePasswordForm.tsx
+++ b/src/components/settings/ChangePasswordForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 
+/* eslint-disable no-unused-vars */
 export default function ChangePasswordForm({ onSave, onCancel }: { onSave: (oldPw: string, newPw: string) => void; onCancel: () => void }) {
   const [oldPw, setOldPw] = useState("");
   const [newPw, setNewPw] = useState("");

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import de from './locales/de.json';
 import en from './locales/en.json';

--- a/src/profile.tsx
+++ b/src/profile.tsx
@@ -3,14 +3,27 @@ import { createRoot } from 'react-dom/client';
 import Profile from './Profile';
 import { I18nProvider } from './i18n';
 
-const params = new URLSearchParams(window.location.search);
-const username = params.get('user') ?? '';
+export function extractUsername(search: string, pathname: string): string {
+  const params = new URLSearchParams(search);
+  const queryUser = params.get('user');
+  if (queryUser) return queryUser;
 
-createRoot(document.getElementById('root')!)
-  .render(
-    <StrictMode>
-      <I18nProvider>
-        <Profile username={username} />
-      </I18nProvider>
-    </StrictMode>,
-  );
+  const match = pathname.match(/^\/(?:profil|profile)\/([^/]+)\/?$/);
+  return match ? decodeURIComponent(match[1]) : '';
+}
+
+let username = '';
+if (typeof window !== 'undefined') {
+  username = extractUsername(window.location.search, window.location.pathname);
+}
+
+if (typeof document !== 'undefined') {
+  createRoot(document.getElementById('root')!)
+    .render(
+      <StrictMode>
+        <I18nProvider>
+          <Profile username={username} />
+        </I18nProvider>
+      </StrictMode>,
+    );
+}

--- a/tests/profile-username.test.ts
+++ b/tests/profile-username.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { extractUsername } from '../src/profile.tsx';
+
+describe('extractUsername', () => {
+  it('prefers query parameter when present', () => {
+    expect(extractUsername('?user=bob', '/profil/ignored')).toBe('bob');
+  });
+
+  it('extracts username from /profil/ path', () => {
+    expect(extractUsername('', '/profil/bob')).toBe('bob');
+  });
+
+  it('handles trailing slash in path', () => {
+    expect(extractUsername('', '/profil/alice/')).toBe('alice');
+  });
+
+  it('supports /profile/ path as well', () => {
+    expect(extractUsername('', '/profile/charlie')).toBe('charlie');
+  });
+
+  it('returns empty string when no username found', () => {
+    expect(extractUsername('', '/profile')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- support username extraction from URL path so profile links like `/profil/bob` load correctly
- add tests covering username parsing from query and path
- clean up unused imports and silence unused variable warnings for a clean lint run

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a249d45d98832dbc3675d150ab000e