### PR TITLE
Switch KV storage to Cloudflare D1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React + Vite
 
-This project now runs entirely on a single **Cloudflare Worker**. The Worker serves the built frontend assets and exposes API routes backed by a Cloudflare KV namespace bound as `DB`.
+This project now runs entirely on a single **Cloudflare Worker**. The Worker serves the built frontend assets and exposes API routes backed by a Cloudflare D1 database bound as `DB`.
 
 ## Development
 
@@ -20,8 +20,17 @@ This project now runs entirely on a single **Cloudflare Worker**. The Worker ser
 
 ## Deployment
 
-1. Create a KV namespace in Cloudflare and bind it as `DB` in `wrangler.toml`.
-2. Deploy the Worker and assets:
+1. Create a D1 database in Cloudflare and bind it as `DB` in `wrangler.toml`.
+2. Ensure the database has the required tables:
+
+   ```sql
+   CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);
+   CREATE TABLE IF NOT EXISTS sessions (token TEXT PRIMARY KEY, user_id INTEGER);
+   CREATE TABLE IF NOT EXISTS user_data (user_id INTEGER PRIMARY KEY, data TEXT);
+   ```
+
+   You can run these with `wrangler d1 execute`.
+3. Deploy the Worker and assets:
 
    ```bash
    npm run deploy

--- a/functions/api/account.js
+++ b/functions/api/account.js
@@ -1,16 +1,12 @@
-import { getDb, saveDb, auth } from '../../shared/utils.js';
+import { auth, deleteUser, deleteUserData, deleteSessionsByUser } from '../../shared/utils.js';
 
 export const onRequestDelete = async ({ request, env }) => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  db.users = db.users.filter(u => u.id !== user.id);
-  delete db.data[user.id];
-  for (const [t, uid] of Object.entries(db.sessions)) {
-    if (uid === user.id) delete db.sessions[t];
-  }
-  await saveDb(env, db);
+  await deleteUser(env, user.id);
+  await deleteUserData(env, user.id);
+  await deleteSessionsByUser(env, user.id);
   return Response.json({ success: true });
 };

--- a/functions/api/data.js
+++ b/functions/api/data.js
@@ -1,22 +1,19 @@
-import { getDb, saveDb, parseBody, auth } from '../../shared/utils.js';
+import { parseBody, auth, getUserData, setUserData } from '../../shared/utils.js';
 
 export const onRequestGet = async ({ request, env }) => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  return Response.json({ data: db.data[user.id] || null });
+  return Response.json({ data: await getUserData(env, user.id) });
 };
 
 export const onRequestPost = async ({ request, env }) => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
   const { data } = await parseBody(request);
-  db.data[user.id] = data;
-  await saveDb(env, db);
+  await setUserData(env, user.id, data);
   return Response.json({ success: true });
 };

--- a/functions/api/login.js
+++ b/functions/api/login.js
@@ -1,14 +1,12 @@
-import { getDb, saveDb, parseBody, verifyPassword, randomHex } from '../../shared/utils.js';
+import { parseBody, verifyPassword, randomHex, getUserByUsername, createSession } from '../../shared/utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
   const { username, password } = await parseBody(request);
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === username);
+  const user = await getUserByUsername(env, username);
   if (!user || !(await verifyPassword(password, user.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 401 });
   }
   const token = randomHex(24);
-  db.sessions[token] = user.id;
-  await saveDb(env, db);
+  await createSession(env, token, user.id);
   return Response.json({ token });
 };

--- a/functions/api/logout.js
+++ b/functions/api/logout.js
@@ -1,12 +1,10 @@
-import { getDb, saveDb } from '../../shared/utils.js';
+import { deleteSession } from '../../shared/utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
-  const db = await getDb(env);
   const authHeader = request.headers.get('authorization');
   if (authHeader) {
     const token = authHeader.split(' ')[1];
-    delete db.sessions[token];
-    await saveDb(env, db);
+    await deleteSession(env, token);
   }
   return Response.json({ success: true });
 };

--- a/functions/api/password.js
+++ b/functions/api/password.js
@@ -1,8 +1,7 @@
-import { getDb, saveDb, parseBody, auth, hashPassword, verifyPassword } from '../../shared/utils.js';
+import { parseBody, auth, hashPassword, verifyPassword, getUserById, updateUserPassword } from '../../shared/utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
@@ -10,11 +9,10 @@ export const onRequestPost = async ({ request, env }) => {
   if (!oldPassword || !newPassword) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const u = db.users.find(u => u.id === user.id);
+  const u = await getUserById(env, user.id);
   if (!u || !(await verifyPassword(oldPassword, u.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 400 });
   }
-  u.password = await hashPassword(newPassword);
-  await saveDb(env, db);
+  await updateUserPassword(env, user.id, await hashPassword(newPassword));
   return Response.json({ success: true });
 };

--- a/functions/api/profile/[username].js
+++ b/functions/api/profile/[username].js
@@ -1,10 +1,9 @@
-import { getDb } from '../../../shared/utils.js';
+import { getUserByUsername, getUserData } from '../../../shared/utils.js';
 
 export const onRequestGet = async ({ env, params }) => {
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === params.username);
+  const user = await getUserByUsername(env, params.username);
   if (!user) {
     return new Response(JSON.stringify({ error: 'notfound' }), { status: 404 });
   }
-  return Response.json({ username: user.username, data: db.data[user.id] || null });
+  return Response.json({ username: user.username, data: await getUserData(env, user.id) });
 };

--- a/functions/api/register.js
+++ b/functions/api/register.js
@@ -1,16 +1,14 @@
-import { getDb, saveDb, parseBody, hashPassword } from '../../shared/utils.js';
+import { parseBody, hashPassword, getUserByUsername, addUser } from '../../shared/utils.js';
 
 export const onRequestPost = async ({ request, env }) => {
   const { username, password } = await parseBody(request);
   if (!username || !password) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const db = await getDb(env);
-  if (db.users.find(u => u.username === username)) {
+  const existing = await getUserByUsername(env, username);
+  if (existing) {
     return new Response(JSON.stringify({ error: 'exists' }), { status: 400 });
   }
-  const id = db.users.length ? Math.max(...db.users.map(u => u.id)) + 1 : 1;
-  db.users.push({ id, username, password: await hashPassword(password) });
-  await saveDb(env, db);
+  await addUser(env, username, await hashPassword(password));
   return Response.json({ success: true });
 };

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -1,12 +1,3 @@
-export async function getDb(env){
-  const data = await env.DB.get('db');
-  return data ? JSON.parse(data) : { users: [], data: {}, sessions: {} };
-}
-
-export async function saveDb(env, db){
-  await env.DB.put('db', JSON.stringify(db));
-}
-
 export async function parseBody(request){
   try {
     return await request.json();
@@ -32,15 +23,71 @@ export async function verifyPassword(password, stored){
   return hashHex === computed;
 }
 
-export function auth(request, db){
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader) return null;
-  const token = authHeader.split(' ')[1];
-  const uid = db.sessions[token];
-  return uid ? { id: uid } : null;
-}
-
 export function randomHex(bytes){
   const arr = crypto.getRandomValues(new Uint8Array(bytes));
   return Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function initDb(db){
+  await db.exec(`CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);
+CREATE TABLE IF NOT EXISTS sessions (token TEXT PRIMARY KEY, user_id INTEGER);
+CREATE TABLE IF NOT EXISTS user_data (user_id INTEGER PRIMARY KEY, data TEXT);`);
+}
+
+export async function getUserByUsername(env, username){
+  return await env.DB.prepare('SELECT id, username, password FROM users WHERE username = ?').bind(username).first();
+}
+
+export async function addUser(env, username, password){
+  await env.DB.prepare('INSERT INTO users (username, password) VALUES (?, ?)').bind(username, password).run();
+}
+
+export async function getUserById(env, id){
+  return await env.DB.prepare('SELECT id, username, password FROM users WHERE id = ?').bind(id).first();
+}
+
+export async function updateUserPassword(env, id, password){
+  await env.DB.prepare('UPDATE users SET password = ? WHERE id = ?').bind(password, id).run();
+}
+
+export async function createSession(env, token, userId){
+  await env.DB.prepare('INSERT INTO sessions (token, user_id) VALUES (?, ?)').bind(token, userId).run();
+}
+
+export async function getUserIdByToken(env, token){
+  const row = await env.DB.prepare('SELECT user_id FROM sessions WHERE token = ?').bind(token).first();
+  return row ? row.user_id : null;
+}
+
+export async function deleteSession(env, token){
+  await env.DB.prepare('DELETE FROM sessions WHERE token = ?').bind(token).run();
+}
+
+export async function deleteSessionsByUser(env, userId){
+  await env.DB.prepare('DELETE FROM sessions WHERE user_id = ?').bind(userId).run();
+}
+
+export async function setUserData(env, userId, data){
+  await env.DB.prepare('INSERT OR REPLACE INTO user_data (user_id, data) VALUES (?, ?)').bind(userId, JSON.stringify(data)).run();
+}
+
+export async function getUserData(env, userId){
+  const row = await env.DB.prepare('SELECT data FROM user_data WHERE user_id = ?').bind(userId).first();
+  return row ? JSON.parse(row.data) : null;
+}
+
+export async function deleteUserData(env, userId){
+  await env.DB.prepare('DELETE FROM user_data WHERE user_id = ?').bind(userId).run();
+}
+
+export async function deleteUser(env, userId){
+  await env.DB.prepare('DELETE FROM users WHERE id = ?').bind(userId).run();
+}
+
+export async function auth(request, env){
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader) return null;
+  const token = authHeader.split(' ')[1];
+  const uid = await getUserIdByToken(env, token);
+  return uid ? { id: uid } : null;
 }

--- a/src/api/account.js
+++ b/src/api/account.js
@@ -1,16 +1,12 @@
-import { getDb, saveDb, auth } from '../../shared/utils.js';
+import { auth, deleteUser, deleteUserData, deleteSessionsByUser } from '../../shared/utils.js';
 
 export async function accountDelete(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  db.users = db.users.filter(u => u.id !== user.id);
-  delete db.data[user.id];
-  for (const [t, uid] of Object.entries(db.sessions)) {
-    if (uid === user.id) delete db.sessions[t];
-  }
-  await saveDb(env, db);
+  await deleteUser(env, user.id);
+  await deleteUserData(env, user.id);
+  await deleteSessionsByUser(env, user.id);
   return Response.json({ success: true });
 }

--- a/src/api/data.js
+++ b/src/api/data.js
@@ -1,22 +1,19 @@
-import { getDb, saveDb, parseBody, auth } from '../../shared/utils.js';
+import { parseBody, auth, getUserData, setUserData } from '../../shared/utils.js';
 
 export async function dataGet(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
-  return Response.json({ data: db.data[user.id] || null });
+  return Response.json({ data: await getUserData(env, user.id) });
 }
 
 export async function dataPost(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
   const { data } = await parseBody(request);
-  db.data[user.id] = data;
-  await saveDb(env, db);
+  await setUserData(env, user.id, data);
   return Response.json({ success: true });
 }

--- a/src/api/login.js
+++ b/src/api/login.js
@@ -1,14 +1,12 @@
-import { getDb, saveDb, parseBody, verifyPassword, randomHex } from '../../shared/utils.js';
+import { parseBody, verifyPassword, randomHex, getUserByUsername, createSession } from '../../shared/utils.js';
 
 export async function login(request, env) {
   const { username, password } = await parseBody(request);
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === username);
+  const user = await getUserByUsername(env, username);
   if (!user || !(await verifyPassword(password, user.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 401 });
   }
   const token = randomHex(24);
-  db.sessions[token] = user.id;
-  await saveDb(env, db);
+  await createSession(env, token, user.id);
   return Response.json({ token });
 }

--- a/src/api/logout.js
+++ b/src/api/logout.js
@@ -1,12 +1,10 @@
-import { getDb, saveDb } from '../../shared/utils.js';
+import { deleteSession } from '../../shared/utils.js';
 
 export async function logout(request, env) {
-  const db = await getDb(env);
   const authHeader = request.headers.get('authorization');
   if (authHeader) {
     const token = authHeader.split(' ')[1];
-    delete db.sessions[token];
-    await saveDb(env, db);
+    await deleteSession(env, token);
   }
   return Response.json({ success: true });
 }

--- a/src/api/password.js
+++ b/src/api/password.js
@@ -1,8 +1,7 @@
-import { getDb, saveDb, parseBody, auth, hashPassword, verifyPassword } from '../../shared/utils.js';
+import { parseBody, auth, hashPassword, verifyPassword, getUserById, updateUserPassword } from '../../shared/utils.js';
 
 export async function password(request, env) {
-  const db = await getDb(env);
-  const user = auth(request, db);
+  const user = await auth(request, env);
   if (!user) {
     return new Response(JSON.stringify({ error: 'noauth' }), { status: 401 });
   }
@@ -10,11 +9,10 @@ export async function password(request, env) {
   if (!oldPassword || !newPassword) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const u = db.users.find(u => u.id === user.id);
+  const u = await getUserById(env, user.id);
   if (!u || !(await verifyPassword(oldPassword, u.password))) {
     return new Response(JSON.stringify({ error: 'invalid' }), { status: 400 });
   }
-  u.password = await hashPassword(newPassword);
-  await saveDb(env, db);
+  await updateUserPassword(env, user.id, await hashPassword(newPassword));
   return Response.json({ success: true });
 }

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -1,10 +1,9 @@
-import { getDb } from '../../shared/utils.js';
+import { getUserByUsername, getUserData } from '../../shared/utils.js';
 
 export async function profileGet(request, env, username) {
-  const db = await getDb(env);
-  const user = db.users.find(u => u.username === username);
+  const user = await getUserByUsername(env, username);
   if (!user) {
     return new Response(JSON.stringify({ error: 'notfound' }), { status: 404 });
   }
-  return Response.json({ username: user.username, data: db.data[user.id] || null });
+  return Response.json({ username: user.username, data: await getUserData(env, user.id) });
 }

--- a/src/api/register.js
+++ b/src/api/register.js
@@ -1,16 +1,14 @@
-import { getDb, saveDb, parseBody, hashPassword } from '../../shared/utils.js';
+import { parseBody, hashPassword, getUserByUsername, addUser } from '../../shared/utils.js';
 
 export async function register(request, env) {
   const { username, password } = await parseBody(request);
   if (!username || !password) {
     return new Response(JSON.stringify({ error: 'missing' }), { status: 400 });
   }
-  const db = await getDb(env);
-  if (db.users.find(u => u.username === username)) {
+  const existing = await getUserByUsername(env, username);
+  if (existing) {
     return new Response(JSON.stringify({ error: 'exists' }), { status: 400 });
   }
-  const id = db.users.length ? Math.max(...db.users.map(u => u.id)) + 1 : 1;
-  db.users.push({ id, username, password: await hashPassword(password) });
-  await saveDb(env, db);
+  await addUser(env, username, await hashPassword(password));
   return Response.json({ success: true });
 }

--- a/tests/d1-mock.js
+++ b/tests/d1-mock.js
@@ -1,0 +1,74 @@
+export function createD1(){
+  const state = { users: [], sessions: [], user_data: [], lastId: 0 };
+  return {
+    async exec(){ /* no-op for schema creation */ },
+    prepare(sql){
+      const stmt = {
+        sql,
+        params: [],
+        bind(...args){ this.params = args; return this; },
+        async first(){ const r = runAll(sql, this.params, state); return r[0] || null; },
+        async run(){ runAll(sql, this.params, state); return { success: true }; },
+        async all(){ return { results: runAll(sql, this.params, state) }; }
+      };
+      return stmt;
+    }
+  };
+}
+
+function runAll(sql, params, state){
+  switch(sql){
+    case 'SELECT id, username, password FROM users WHERE username = ?':
+      return state.users.filter(u => u.username === params[0]);
+    case 'INSERT INTO users (username, password) VALUES (?, ?)': {
+      const id = ++state.lastId;
+      state.users.push({ id, username: params[0], password: params[1] });
+      return [];
+    }
+    case 'SELECT id, username, password FROM users WHERE id = ?':
+      return state.users.filter(u => u.id === params[0]);
+    case 'UPDATE users SET password = ? WHERE id = ?': {
+      const u = state.users.find(u => u.id === params[1]);
+      if (u) u.password = params[0];
+      return [];
+    }
+    case 'INSERT INTO sessions (token, user_id) VALUES (?, ?)': {
+      state.sessions.push({ token: params[0], user_id: params[1] });
+      return [];
+    }
+    case 'SELECT user_id FROM sessions WHERE token = ?':
+      return state.sessions.filter(s => s.token === params[0]).map(s => ({ user_id: s.user_id }));
+    case 'DELETE FROM sessions WHERE token = ?':
+      state.sessions = state.sessions.filter(s => s.token !== params[0]);
+      return [];
+    case 'DELETE FROM sessions WHERE user_id = ?': {
+      state.sessions = state.sessions.filter(s => s.user_id !== params[0]);
+      return [];
+    }
+    case 'INSERT OR REPLACE INTO user_data (user_id, data) VALUES (?, ?)': {
+      const idx = state.user_data.findIndex(d => d.user_id === params[0]);
+      const row = { user_id: params[0], data: params[1] };
+      if (idx >= 0) state.user_data[idx] = row; else state.user_data.push(row);
+      return [];
+    }
+    case 'SELECT data FROM user_data WHERE user_id = ?': {
+      return state.user_data.filter(d => d.user_id === params[0]).map(d => ({ data: d.data }));
+    }
+    case 'DELETE FROM user_data WHERE user_id = ?': {
+      state.user_data = state.user_data.filter(d => d.user_id !== params[0]);
+      return [];
+    }
+    case 'DELETE FROM users WHERE id = ?': {
+      state.users = state.users.filter(u => u.id !== params[0]);
+      return [];
+    }
+    case 'SELECT id, username FROM users':
+      return state.users.map(u => ({ id: u.id, username: u.username }));
+    case 'SELECT user_id, data FROM user_data':
+      return state.user_data.map(d => ({ user_id: d.user_id, data: d.data }));
+    case 'SELECT token, user_id FROM sessions':
+      return state.sessions.map(s => ({ token: s.token, user_id: s.user_id }));
+    default:
+      throw new Error('Unsupported SQL: ' + sql);
+  }
+}

--- a/tests/password.test.js
+++ b/tests/password.test.js
@@ -2,15 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { onRequestPost as register } from '../functions/api/register.js';
 import { onRequestPost as login } from '../functions/api/login.js';
 import { onRequestPost as password } from '../functions/api/password.js';
+import { initDb } from '../shared/utils.js';
+import { createD1 } from './d1-mock.js';
 
 function makeEnv(){
-  const store = {};
-  return {
-    DB: {
-      async get(key){ return store[key] || null; },
-      async put(key, val){ store[key] = val; }
-    }
-  };
+  return { DB: createD1() };
 }
 
 function makeRequest(url, method, body, token){
@@ -26,8 +22,9 @@ function makeRequest(url, method, body, token){
 
 let env;
 
-beforeEach(() => {
+beforeEach(async () => {
   env = makeEnv();
+  await initDb(env.DB);
 });
 
 describe('password change', () => {

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -3,15 +3,11 @@ import { onRequestPost as register } from '../functions/api/register.js';
 import { onRequestPost as login } from '../functions/api/login.js';
 import { onRequestPost as dataPost } from '../functions/api/data.js';
 import { onRequestGet as profileGet } from '../functions/api/profile/[username].js';
+import { initDb } from '../shared/utils.js';
+import { createD1 } from './d1-mock.js';
 
 function makeEnv(){
-  const store = {};
-  return {
-    DB: {
-      async get(key){ return store[key] || null; },
-      async put(key, val){ store[key] = val; }
-    }
-  };
+  return { DB: createD1() };
 }
 
 function makeRequest(url, method, body, token){
@@ -27,8 +23,9 @@ function makeRequest(url, method, body, token){
 
 let env;
 
-beforeEach(() => {
+beforeEach(async () => {
   env = makeEnv();
+  await initDb(env.DB);
 });
 
 describe('profile endpoint', () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,10 +4,10 @@ compatibility_date = "2024-05-01"
 
 assets = { directory = "dist", binding = "ASSETS" }
 
-[[kv_namespaces]]
+[[d1_databases]]
 binding = "DB"
-id = "37acae97c20240979b10e8b9a61a1e41"
-preview_id = "94fcb0dea86d42d19033bc0612955df8"
+database_name = "zufallstour-3000"
+database_id = "227a9d95-f3e1-48b2-bcf5-6a4a4e91f27d"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Summary
- configure `DB` as a Cloudflare D1 database
- replace KV helpers with SQL-based helpers and update API routes
- adjust tests to use an in-memory D1 mock and document new setup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a260e54e00832d90daf87135919128