### PR TITLE
Fix profile text placeholders and share global styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/index.css" />
     <title>Zufallstour 3000 Berlin</title>
    <script>
       const isLocal = ['localhost', '127.0.0.1'].includes(location.hostname)

--- a/profile.html
+++ b/profile.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/index.css" />
     <title>Zufallstour 3000 Berlin</title>
    <script>
       const isLocal = ['localhost', '127.0.0.1'].includes(location.hostname)

--- a/src/Profile.jsx
+++ b/src/Profile.jsx
@@ -1,16 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { stationLabel } from './App.jsx';
 import { useI18n } from './i18n.jsx';
-
-function formatDate(iso){
-  if(!iso) return '';
-  try {
-    const d = new Date(iso + (iso.length === 10 ? 'T00:00:00' : ''));
-    return d.toLocaleDateString('de-DE',{year:'numeric',month:'2-digit',day:'2-digit'});
-  } catch {
-    return iso;
-  }
-}
+import { formatDate } from './formatDate.js';
+import MilestonesView from './components/milestones/MilestonesView.jsx';
+import LineChips from './components/LineChips.jsx';
 
 export default function Profile({ username }) {
   const { t } = useI18n();
@@ -52,44 +45,6 @@ export default function Profile({ username }) {
     });
     return stats;
   },[stations]);
-  const firstVisitDates = useMemo(()=> (stations||[]).map(s=>s.visits[0]?.date).filter(Boolean).sort(), [stations]);
-
-  const milestones = useMemo(()=>{
-    if(!stations) return [];
-    const stationMilestones=[
-      { label:t('profile.milestone.first'), count:1, desc:t('profile.milestone.firstDesc') },
-      { label:t('profile.milestone.hattrick'), count:3, desc:t('profile.milestone.hattrickDesc') },
-      { label:'10%', percent:10 },
-      { label:'25%', percent:25 },
-      { label:'50%', percent:50 },
-      { label:'75%', percent:75 },
-      { label:t('profile.milestone.almost'), count:Math.max(total-3,0), desc:t('profile.milestone.almostDesc') },
-      { label:'100%', percent:100 },
-    ].map(m=>{
-      const count=m.count ?? Math.ceil(total*(m.percent/100));
-      const done=visitedCount>=count;
-      const date=done?firstVisitDates[count-1]:null;
-      return {...m,done,date};
-    }).filter(m=>m.done);
-    const network=[
-      { label:t('profile.milestone.allS'), stat:typeStats.S },
-      { label:t('profile.milestone.allU'), stat:typeStats.U },
-      { label:t('profile.milestone.allR'), stat:typeStats.R },
-    ].map(({label,stat})=>{
-      const done=stat.visited>=stat.total && stat.total>0;
-      const dates=(stations||[]).filter(s=>s.visits[0]?.date && s.types.includes(label.includes('S')?'S':label.includes('U')?'U':'R')).map(s=>s.visits[0].date).sort();
-      const date=done?dates[stat.total-1]:null;
-      return {label,done,date};
-    }).filter(m=>m.done);
-    const lines=Object.entries(lineIndex).map(([line,stat])=>{
-      const done=stat.visited>=stat.total && stat.total>0;
-      const dates=(stations||[]).filter(s=>(s.lines||[]).includes(line) && s.visits[0]?.date).map(s=>s.visits[0].date).sort();
-      const date=done?dates[stat.total-1]:null;
-      return {label:t('profile.milestone.line',{line}),done,date};
-    }).filter(m=>m.done);
-    return [...stationMilestones,...network,...lines];
-  },[stations,total,visitedCount,firstVisitDates,typeStats,lineIndex,t]);
-
   if(error) return <div className="p-4">{t('profile.notFound')}</div>;
   if(!stations) return <div className="p-4">{t('profile.loading')}</div>;
 
@@ -98,22 +53,38 @@ export default function Profile({ username }) {
       <h1 className="text-2xl font-extrabold">{t('profile.title',{username})}</h1>
       <section>
         <h2 className="text-xl font-bold mb-2">{t('profile.milestones')}</h2>
-        {milestones.length===0 && <div className="text-sm">{t('profile.noMilestones')}</div>}
-        <ul className="list-disc ml-5 space-y-1">
-          {milestones.map(m=> (
-            <li key={m.label}>{m.label}{m.date?` – ${formatDate(m.date)}`:''}</li>
-          ))}
-        </ul>
+        <MilestonesView
+          percent={percent}
+          visitedCount={visitedCount}
+          total={total}
+          lineIndex={lineIndex}
+          typeStats={typeStats}
+          stations={stations}
+        />
       </section>
       <section>
         <h2 className="text-xl font-bold mb-2">{t('profile.visited')}</h2>
         <div className="text-sm mb-2">{visitedCount}/{total} ({percent}%)</div>
         {visitedStations.length===0 && <div className="text-sm">{t('profile.noneVisited')}</div>}
-        <ul className="list-disc ml-5 space-y-1">
-          {visitedStations.map(s=> (
-            <li key={s.id}>{stationLabel(s)}{s.visits[0]?.date?` – ${formatDate(s.visits[0].date)}`:''}</li>
+        <div className="space-y-2">
+          {visitedStations.map(s => (
+            <div key={s.id} className="p-2 border-4 border-black rounded-xl bg-white/80">
+              <div className="font-extrabold truncate">{stationLabel(s)}</div>
+              <LineChips lines={s.lines} types={s.types} />
+              <div className="text-xs mt-1">{t('station.visitedOn')} <b>{formatDate(s.visits[0].date)}</b></div>
+              <div className="mt-2 grid grid-cols-2 sm:grid-cols-4 gap-2">
+                {s.visits.flatMap(v => v.photos || []).map((p, idx) => (
+                  <img
+                    key={idx}
+                    src={p}
+                    alt="Foto"
+                    className="w-full h-32 sm:h-48 object-cover rounded-xl border-2 border-black"
+                  />
+                ))}
+              </div>
+            </div>
           ))}
-        </ul>
+        </div>
       </section>
     </div>
   );

--- a/src/components/milestones/MilestonesModal.jsx
+++ b/src/components/milestones/MilestonesModal.jsx
@@ -1,18 +1,6 @@
-import React, { useMemo } from "react";
-import { Check } from "lucide-react";
+import React from "react";
 import Modal from "../Modal";
-import { formatDate } from "../../formatDate.js";
-
-function HoverCard({ info, children }) {
-  return (
-    <div className="relative group">
-      {children}
-      <div className="pointer-events-none absolute z-20 hidden group-hover:block group-focus-within:block left-1/2 -translate-x-1/2 top-full mt-1 w-56 p-2 rounded-lg border-2 border-black bg-white text-xs shadow">
-        {info}
-      </div>
-    </div>
-  );
-}
+import MilestonesView from "./MilestonesView.jsx";
 
 export default function MilestonesModal({
   open,
@@ -24,134 +12,17 @@ export default function MilestonesModal({
   typeStats,
   stations,
 }) {
-  const firstVisitDates = useMemo(
-    () => stations.map((s) => s.visits[0]?.date).filter(Boolean).sort(),
-    [stations]
-  );
-  const dateForCount = (n) => firstVisitDates[n - 1] || null;
-  const { S = { total: 0, visited: 0 }, U = { total: 0, visited: 0 }, R = { total: 0, visited: 0 } } = typeStats || {};
   if (!open) return null;
-  const stationMilestones = [
-    { label: "1. Besuch", count: 1, desc: "Erster besuchter Bahnhof" },
-    { label: "Hattrick", count: 3, desc: "3 besuchte Bahnhöfe" },
-    { label: "10%", percent: 10 },
-    { label: "25%", percent: 25 },
-    { label: "50%", percent: 50 },
-    { label: "75%", percent: 75 },
-    { label: "Fast geschafft!", count: Math.max(total - 3, 0), desc: "Nur noch 3 Bahnhöfe bis 100%" },
-    { label: "100%", percent: 100 },
-  ].map((m) => {
-    const count = m.count ?? Math.ceil(total * (m.percent / 100));
-    const done = visitedCount >= count;
-    const date = done ? dateForCount(count) : null;
-    const base = m.percent
-      ? `${m.label} - das entspricht ${Math.round(total * (m.percent / 100))} besuchten Bahnhöfen`
-      : m.desc;
-    const info = done ? `${base}. Erreicht am: ${formatDate(date)}` : `${base}. Noch nicht erreicht.`;
-    return { ...m, count, done, info };
-  });
   return (
     <Modal open={open} onClose={onClose} title="Meilensteine">
-      <div className="space-y-6">
-        <section>
-          <div className="font-extrabold mb-2">Gesamt-Fortschritt</div>
-          <div className="w-full h-4 rounded-full border-4 border-black bg-white overflow-hidden">
-            {percent > 0 && <div className="h-full bg-green-500" style={{ width: `${percent}%` }} />}
-          </div>
-          <div className="text-sm mt-1">{visitedCount}/{total} ({percent}%)</div>
-        </section>
-        <section>
-          <div className="font-extrabold mb-2">Stationen-Ziele</div>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-            {stationMilestones.map((m) => (
-              <HoverCard key={m.label} info={m.info}>
-                <button
-                  type="button"
-                  className={`w-full rounded-xl border-4 border-black p-2 text-center ${m.done ? "bg-green-300" : "bg-white"}`}
-                >
-                  <div className="font-black">{m.label}</div>
-                  <div className="text-xs flex items-center justify-center gap-1">
-                    {m.done ? <Check size={14} /> : null} {m.done ? "erreicht" : "offen"}
-                  </div>
-                </button>
-              </HoverCard>
-            ))}
-          </div>
-        </section>
-        <section>
-          <div className="font-extrabold mb-2">Netz-Ziele</div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {[
-              { label: "100% S-Bahnhöfe", stat: S, type: "S" },
-              { label: "100% U-Bahnhöfe", stat: U, type: "U" },
-              { label: "100% Regionalbahnhöfe", stat: R, type: "R" },
-            ].map(({ label, stat, type }) => {
-              const done = stat.visited >= stat.total && stat.total > 0;
-              const pct = stat.total ? Math.round((stat.visited / stat.total) * 100) : 0;
-              const dates = stations
-                .filter((s) => s.types.includes(type) && s.visits[0]?.date)
-                .map((s) => s.visits[0].date)
-                .sort();
-              const date = done ? dates[stat.total - 1] : null;
-              const info = done
-                ? `${label} - erreicht am: ${formatDate(date)}`
-                : `${stat.visited}/${stat.total} Bahnhöfe (${pct}%)`;
-              return (
-                <HoverCard key={label} info={info}>
-                  <button
-                    type="button"
-                    className={`w-full rounded-xl border-4 border-black p-2 text-center ${done ? "bg-green-300" : "bg-white"}`}
-                  >
-                    <div className="font-black">{label}</div>
-                    <div className="text-xs flex items-center justify-center gap-1">
-                      {done ? <Check size={14} /> : null} {done ? "erreicht" : `${stat.visited}/${stat.total} (${pct}%)`}
-                    </div>
-                  </button>
-                </HoverCard>
-              );
-            })}
-          </div>
-        </section>
-        <section>
-          <div className="font-extrabold mb-2">Linien</div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-            {Object.entries(lineIndex).map(([line, stat]) => {
-              const done = stat.visited >= stat.total && stat.total > 0;
-              const pct = Math.round((stat.visited / stat.total) * 100);
-              const visitedStations = stations.filter(
-                (s) => (s.lines || []).includes(line) && s.visits.length > 0
-              );
-              const visitedNames = visitedStations.map((s) => s.name);
-              const dates = visitedStations
-                .map((s) => s.visits[0]?.date)
-                .filter(Boolean)
-                .sort();
-              const date = done ? dates[stat.total - 1] : null;
-              const info = visitedNames.length
-                ? done
-                  ? `Alle Bahnhöfe besucht${date ? ` am ${formatDate(date)}` : ""}`
-                  : `Besuchte Bahnhöfe: ${visitedNames.join(", ")}`
-                : "Noch keine Bahnhöfe besucht";
-              return (
-                <HoverCard key={line} info={info}>
-                  <button
-                    type="button"
-                    className={`w-full rounded-xl border-4 border-black p-2 ${done ? "bg-green-200" : "bg-white"}`}
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="px-2 py-0.5 text-xs font-black rounded-full border-2 border-black bg-white">{line}</span>
-                      <div className="text-xs ml-auto">{stat.visited}/{stat.total} ({pct}%)</div>
-                    </div>
-                    <div className="w-full h-3 rounded-full border-2 border-black bg-white overflow-hidden">
-                      {pct > 0 && <div className="h-full bg-green-500" style={{ width: `${pct}%` }} />}
-                    </div>
-                  </button>
-                </HoverCard>
-              );
-            })}
-          </div>
-        </section>
-      </div>
+      <MilestonesView
+        percent={percent}
+        visitedCount={visitedCount}
+        total={total}
+        lineIndex={lineIndex}
+        typeStats={typeStats}
+        stations={stations}
+      />
     </Modal>
   );
 }

--- a/src/components/milestones/MilestonesView.jsx
+++ b/src/components/milestones/MilestonesView.jsx
@@ -1,0 +1,147 @@
+import React, { useMemo } from "react";
+import { Check } from "lucide-react";
+import { formatDate } from "../../formatDate.js";
+
+function HoverCard({ info, children }) {
+  return (
+    <div className="relative group">
+      {children}
+      <div className="pointer-events-none absolute z-20 hidden group-hover:block group-focus-within:block left-1/2 -translate-x-1/2 top-full mt-1 w-56 p-2 rounded-lg border-2 border-black bg-white text-xs shadow">
+        {info}
+      </div>
+    </div>
+  );
+}
+
+export default function MilestonesView({ percent, visitedCount, total, lineIndex, typeStats, stations }) {
+  const firstVisitDates = useMemo(
+    () => stations.map((s) => s.visits[0]?.date).filter(Boolean).sort(),
+    [stations]
+  );
+  const dateForCount = (n) => firstVisitDates[n - 1] || null;
+  const { S = { total: 0, visited: 0 }, U = { total: 0, visited: 0 }, R = { total: 0, visited: 0 } } = typeStats || {};
+
+  const stationMilestones = [
+    { label: "1. Besuch", count: 1, desc: "Erster besuchter Bahnhof" },
+    { label: "Hattrick", count: 3, desc: "3 besuchte Bahnhöfe" },
+    { label: "10%", percent: 10 },
+    { label: "25%", percent: 25 },
+    { label: "50%", percent: 50 },
+    { label: "75%", percent: 75 },
+    { label: "Fast geschafft!", count: Math.max(total - 3, 0), desc: "Nur noch 3 Bahnhöfe bis 100%" },
+    { label: "100%", percent: 100 },
+  ].map((m) => {
+    const count = m.count ?? Math.ceil(total * (m.percent / 100));
+    const done = visitedCount >= count;
+    const date = done ? dateForCount(count) : null;
+    const base = m.percent
+      ? `${m.label} - das entspricht ${Math.round(total * (m.percent / 100))} besuchten Bahnhöfen`
+      : m.desc;
+    const info = done ? `${base}. Erreicht am: ${formatDate(date)}` : `${base}. Noch nicht erreicht.`;
+    return { ...m, count, done, info };
+  });
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <div className="font-extrabold mb-2">Gesamt-Fortschritt</div>
+        <div className="w-full h-4 rounded-full border-4 border-black bg-white overflow-hidden">
+          {percent > 0 && <div className="h-full bg-green-500" style={{ width: `${percent}%` }} />}
+        </div>
+        <div className="text-sm mt-1">{visitedCount}/{total} ({percent}%)</div>
+      </section>
+      <section>
+        <div className="font-extrabold mb-2">Stationen-Ziele</div>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          {stationMilestones.map((m) => (
+            <HoverCard key={m.label} info={m.info}>
+              <button
+                type="button"
+                className={`w-full rounded-xl border-4 border-black p-2 text-center ${m.done ? "bg-green-300" : "bg-white"}`}
+              >
+                <div className="font-black">{m.label}</div>
+                <div className="text-xs flex items-center justify-center gap-1">
+                  {m.done ? <Check size={14} /> : null} {m.done ? "erreicht" : "offen"}
+                </div>
+              </button>
+            </HoverCard>
+          ))}
+        </div>
+      </section>
+      <section>
+        <div className="font-extrabold mb-2">Netz-Ziele</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {[
+            { label: "100% S-Bahnhöfe", stat: S, type: "S" },
+            { label: "100% U-Bahnhöfe", stat: U, type: "U" },
+            { label: "100% Regionalbahnhöfe", stat: R, type: "R" },
+          ].map(({ label, stat, type }) => {
+            const done = stat.visited >= stat.total && stat.total > 0;
+            const pct = stat.total ? Math.round((stat.visited / stat.total) * 100) : 0;
+            const dates = stations
+              .filter((s) => s.types.includes(type) && s.visits[0]?.date)
+              .map((s) => s.visits[0].date)
+              .sort();
+            const date = done ? dates[stat.total - 1] : null;
+            const info = done
+              ? `${label} - erreicht am: ${formatDate(date)}`
+              : `${stat.visited}/${stat.total} Bahnhöfe (${pct}%)`;
+            return (
+              <HoverCard key={label} info={info}>
+                <button
+                  type="button"
+                  className={`w-full rounded-xl border-4 border-black p-2 text-center ${done ? "bg-green-300" : "bg-white"}`}
+                >
+                  <div className="font-black">{label}</div>
+                  <div className="text-xs flex items-center justify-center gap-1">
+                    {done ? <Check size={14} /> : null} {done ? "erreicht" : `${stat.visited}/${stat.total} (${pct}%)`}
+                  </div>
+                </button>
+              </HoverCard>
+            );
+          })}
+        </div>
+      </section>
+      <section>
+        <div className="font-extrabold mb-2">Linien</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {Object.entries(lineIndex).map(([line, stat]) => {
+            const done = stat.visited >= stat.total && stat.total > 0;
+            const pct = Math.round((stat.visited / stat.total) * 100);
+            const visitedStations = stations.filter(
+              (s) => (s.lines || []).includes(line) && s.visits.length > 0
+            );
+            const visitedNames = visitedStations.map((s) => s.name);
+            const dates = visitedStations
+              .map((s) => s.visits[0]?.date)
+              .filter(Boolean)
+              .sort();
+            const date = done ? dates[stat.total - 1] : null;
+            const info = visitedNames.length
+              ? done
+                ? `Alle Bahnhöfe besucht${date ? ` am ${formatDate(date)}` : ""}`
+                : `Besuchte Bahnhöfe: ${visitedNames.join(", ")}`
+              : "Noch keine Bahnhöfe besucht";
+            return (
+              <HoverCard key={line} info={info}>
+                <button
+                  type="button"
+                  className={`w-full rounded-xl border-4 border-black p-2 ${done ? "bg-green-200" : "bg-white"}`}
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="px-2 py-0.5 text-xs font-black rounded-full border-2 border-black bg-white">{line}</span>
+                    <div className="text-xs ml-auto">{stat.visited}/{stat.total} ({pct}%)</div>
+                  </div>
+                  <div className="w-full h-3 rounded-full border-2 border-black bg-white overflow-hidden">
+                    {pct > 0 && <div className="h-full bg-green-500" style={{ width: `${pct}%` }} />}
+                  </div>
+                </button>
+              </HoverCard>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/i18n.jsx
+++ b/src/i18n.jsx
@@ -12,7 +12,13 @@ export function I18nProvider({ children }) {
     document.documentElement.lang = lang;
     document.title = translations[lang]['app.title'] || 'Zufallstour 3000';
   }, [lang]);
-  const t = (key) => translations[lang][key] || key;
+  const t = (key, vars = {}) => {
+    let str = translations[lang][key] || key;
+    Object.entries(vars).forEach(([vk, vv]) => {
+      str = str.replace(new RegExp(`{{${vk}}}`, 'g'), String(vv));
+    });
+    return str;
+  };
   return (
     <I18nContext.Provider value={{ lang, setLang, t }}>
       {children}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import App from './App.jsx'
 import { I18nProvider } from './i18n.jsx'
 

--- a/src/profile.jsx
+++ b/src/profile.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import Profile from './Profile.jsx'
 import { I18nProvider } from './i18n.jsx'
 


### PR DESCRIPTION
## Summary
- interpolate i18n placeholders so profile names and line numbers render
- load shared Tailwind CSS from HTML entries
- remove CSS imports from entry points to rely on common stylesheet
- factor out milestone cards into shared component and use on profile
- render visited stations as cards with line chips and photos

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e74867974832d9803d8dd0c8fbe94